### PR TITLE
R2/V8: colorthief準拠 OkLch Vibrant+Muted スコアリング

### DIFF
--- a/debug/palettes/colorthief/genshin.svg
+++ b/debug/palettes/colorthief/genshin.svg
@@ -88,22 +88,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#ac8b8e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ac8b8e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#656db5" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#656db5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#656db5</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
-    <rect x="175" y="305" width="155" height="30" fill="#9da5af" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9da5af</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b6440c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6440c</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.71</text>
-    <rect x="485" y="305" width="155" height="30" fill="#d7cabf" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7cabf</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.54</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#656db5</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9da5af" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9da5af</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b6440c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6440c</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.71</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d7cabf" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7cabf</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.54</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8c736f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c736f</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.05</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#ac8b8e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8b8e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.89</text>
   </g>
   <g transform="translate(0,372)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Alhaitham</text>
@@ -307,14 +315,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#6b616c" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6b616c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#d2322a" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d2322a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d2322a</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
-    <rect x="330" y="305" width="310" height="30" fill="#7e6e69" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6e69</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.24</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d2322a</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7e6e69" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6e69</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.24</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cba783" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba783</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e8d6cb" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8d6cb</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b1aab3" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1aab3</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.64</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9f919e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f919e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
   </g>
   <g transform="translate(0,1076)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">AratakiItto</text>
@@ -405,21 +429,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#333432" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#333432</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c34225" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c34225</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.02</text>
-    <rect x="175" y="305" width="155" height="30" fill="#82625f" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#82625f</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.71</text>
-    <rect x="330" y="305" width="155" height="30" fill="#da8c35" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8c35</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
-    <rect x="485" y="305" width="155" height="30" fill="#e6c8a1" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e6c8a1</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5d476f" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d476f</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.77</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9086a1" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9086a1</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.10</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c34225" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c34225</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.02</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#82625f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#82625f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.71</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#da8c35" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8c35</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e6c8a1" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e6c8a1</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.48</text>
   </g>
   <g transform="translate(0,1428)">
@@ -512,14 +544,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#aca074" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#aca074</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c01415" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01415</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
-    <rect x="330" y="305" width="310" height="30" fill="#cc7d75" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc7d75</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.97</text>
+    <rect x="20" y="305" width="124" height="30" fill="#8d929d" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#8d929d</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.33</text>
+    <rect x="144" y="305" width="124" height="30" fill="#a2a8b1" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2a8b1</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <rect x="268" y="305" width="124" height="30" fill="#c01415" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01415</text>
+    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="392" y="305" width="124" height="30" fill="#cc7d75" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc7d75</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.97</text>
+    <rect x="516" y="305" width="124" height="30" fill="#aca074" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#aca074</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.59</text>
   </g>
   <g transform="translate(0,1780)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Baizhu</text>
@@ -609,21 +653,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#8e896e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8e896e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#5954bc" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5954bc" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5954bc</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
-    <rect x="175" y="305" width="155" height="30" fill="#9eb0c4" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9eb0c4</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.33</text>
-    <rect x="330" y="305" width="155" height="30" fill="#18beae" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#18beae</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
-    <rect x="485" y="305" width="155" height="30" fill="#509ca5" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#509ca5</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5954bc</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9eb0c4" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9eb0c4</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.33</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#18beae" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#18beae</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#509ca5" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#509ca5</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#957944" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#957944</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.92</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8e896e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e896e</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
   </g>
   <g transform="translate(0,2132)">
@@ -716,22 +768,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#746f70" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#746f70</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#3696bf" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#3696bf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#3696bf</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
-    <rect x="175" y="305" width="155" height="30" fill="#b1b1ba" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1b1ba</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.42</text>
-    <rect x="330" y="305" width="155" height="30" fill="#ce7c59" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ce7c59</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.60</text>
-    <rect x="485" y="305" width="155" height="30" fill="#9b8778" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8778</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.18</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#3696bf</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
+    <rect x="144" y="305" width="124" height="30" fill="#b1b1ba" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1b1ba</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.42</text>
+    <rect x="268" y="305" width="124" height="30" fill="#ce7c59" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#ce7c59</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.60</text>
+    <rect x="392" y="305" width="124" height="30" fill="#9b8778" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8778</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.18</text>
+    <rect x="516" y="305" width="124" height="30" fill="#746f70" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#746f70</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
   </g>
   <g transform="translate(0,2484)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Beidou</text>
@@ -821,22 +877,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#524c43" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#524c43</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#ba3549" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba3549" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba3549</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
-    <rect x="175" y="305" width="155" height="30" fill="#b57a70" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b57a70</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
-    <rect x="330" y="305" width="155" height="30" fill="#ae6a5b" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae6a5b</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c19981" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c19981</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.53</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba3549</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b57a70" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b57a70</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9783a5" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9783a5</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.91</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#83acb6" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#83acb6</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.57</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ae6a5b" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae6a5b</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e4ccc1" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e4ccc1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
   </g>
   <g transform="translate(0,2836)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Bennett</text>
@@ -927,14 +991,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#3d4e5b" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3d4e5b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#cf1308" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cf1308" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cf1308</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
-    <rect x="330" y="305" width="310" height="30" fill="#e0c9b3" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0c9b3</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cf1308</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e0c9b3" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0c9b3</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a39cb2" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a39cb2</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.16</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#2a2937" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2a2937</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6d7074" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d7074</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.46</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3d4e5b" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d4e5b</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
   </g>
   <g transform="translate(0,3188)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Candace</text>
@@ -1139,21 +1219,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#326399" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#326399</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c54e75" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c54e75" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c54e75</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
-    <rect x="175" y="305" width="155" height="30" fill="#b1787e" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1787e</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
-    <rect x="330" y="305" width="155" height="30" fill="#3da5af" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da5af</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
-    <rect x="485" y="305" width="155" height="30" fill="#747d8a" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#747d8a</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c54e75</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b1787e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1787e</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#86704b" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#86704b</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.52</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bfaa81" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bfaa81</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3da5af" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da5af</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#747d8a" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#747d8a</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
   </g>
   <g transform="translate(0,3892)">
@@ -1245,22 +1333,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#44334e" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#44334e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#be483f" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#be483f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#be483f</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a2947c" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2947c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
-    <rect x="330" y="305" width="155" height="30" fill="#6271a8" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6271a8</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
-    <rect x="485" y="305" width="155" height="30" fill="#869cb9" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#869cb9</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
+    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#be483f</text>
+    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
+    <rect x="144" y="305" width="124" height="30" fill="#a2947c" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2947c</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
+    <rect x="268" y="305" width="124" height="30" fill="#6271a8" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6271a8</text>
+    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
+    <rect x="392" y="305" width="124" height="30" fill="#869cb9" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#869cb9</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
+    <rect x="516" y="305" width="124" height="30" fill="#44334e" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#44334e</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.97</text>
   </g>
   <g transform="translate(0,4244)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chevreuse</text>
@@ -1466,22 +1558,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#9587b1" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#9587b1</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#ba341e" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba341e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba341e</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
-    <rect x="175" y="305" width="155" height="30" fill="#864f40" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#864f40</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
-    <rect x="330" y="305" width="155" height="30" fill="#cd8934" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8934</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c3a38d" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3a38d</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba341e</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#864f40" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#864f40</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd8934" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8934</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c3a38d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3a38d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9587b1" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9587b1</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#53576a" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#53576a</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
   </g>
   <g transform="translate(0,4948)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chongyun</text>
@@ -1573,14 +1673,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#1d1b1d" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#1d1b1d</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c48464" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48464</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.24</text>
-    <rect x="330" y="305" width="310" height="30" fill="#978a7d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#978a7d</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.45</text>
+    <rect x="20" y="305" width="124" height="30" fill="#6b9dc3" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b9dc3</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="144" y="305" width="124" height="30" fill="#618aa9" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#618aa9</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.53</text>
+    <rect x="268" y="305" width="124" height="30" fill="#c48464" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48464</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.24</text>
+    <rect x="392" y="305" width="124" height="30" fill="#978a7d" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#978a7d</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.45</text>
+    <rect x="516" y="305" width="124" height="30" fill="#1d1b1d" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1d1b1d</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=4.52</text>
   </g>
   <g transform="translate(0,5300)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Citlali</text>
@@ -1672,18 +1784,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#408ca0" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#408ca0</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#886cc3" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#886cc3" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#886cc3</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
-    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#785e7a" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#785e7a</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
-    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#408ca0" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#886cc3</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#785e7a" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#785e7a</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#e3a7c0" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3a7c0</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.67</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#71554c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71554c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.02</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#408ca0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="536.6666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#408ca0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.06</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#408ca0</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.06</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#92e6f4" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#92e6f4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
   </g>
   <g transform="translate(0,5652)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Clorinde</text>
@@ -1775,14 +1899,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#a78356" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a78356</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c45ce4" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c45ce4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c45ce4</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
-    <rect x="330" y="305" width="310" height="30" fill="#646c6e" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#646c6e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c45ce4</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#646c6e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#646c6e</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a78282" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78282</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.66</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c7c1c0" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7c1c0</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a78356" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78356</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7e6b61" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6b61</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.19</text>
   </g>
   <g transform="translate(0,6004)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Collei</text>
@@ -1873,14 +2013,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#8c3484" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8c3484</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#edbd75" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#be9c6a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#edbd75</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.68</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#be9c6a" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#be9c6a</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.78</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#897f5c" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#be9c6a</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#897f5c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.79</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6cac3c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6cac3c</text>
@@ -2102,14 +2242,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#444649" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#444649</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#bd465e" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bd465e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bd465e</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.78</text>
-    <rect x="330" y="305" width="310" height="30" fill="#c5988b" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c5988b</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bd465e</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.78</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c5988b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c5988b</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c08e6c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08e6c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.94</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a3a398" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a3a398</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.43</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6e85a1" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6e85a1</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.65</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6c6e74" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c6e74</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.88</text>
   </g>
   <g transform="translate(0,7060)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Dehya</text>
@@ -2201,22 +2357,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#a4949c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#a4949c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c71a11" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c71a11" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c71a11</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.26</text>
-    <rect x="175" y="305" width="155" height="30" fill="#c47958" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47958</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.05</text>
-    <rect x="330" y="305" width="155" height="30" fill="#da8b33" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8b33</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.77</text>
-    <rect x="485" y="305" width="155" height="30" fill="#a99e84" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e84</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c71a11</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.26</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c47958" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47958</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.05</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#da8b33" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8b33</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.77</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a99e84" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e84</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a4949c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4949c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.13</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6d5a64" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d5a64</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
   </g>
   <g transform="translate(0,7412)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Diluc</text>
@@ -2306,14 +2470,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#8c8c94" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#8c8c94</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#cc472d" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cc472d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cc472d</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.18</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b69482" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69482</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cc472d</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.18</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b69482" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69482</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#879596" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#879596</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.19</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#545c5c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#545c5c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.46</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8c8c94" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8c94</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.13</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#51535c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#51535c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.39</text>
   </g>
   <g transform="translate(0,7764)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Diona</text>
@@ -2518,21 +2698,29 @@
     <rect x="360" y="257" width="70" height="28" fill="#d26e87" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#d26e87</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#5f39c0" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5f39c0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5f39c0</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
-    <rect x="175" y="305" width="155" height="30" fill="#8883a7" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8883a7</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.70</text>
-    <rect x="330" y="305" width="155" height="30" fill="#d26e87" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d26e87</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
-    <rect x="485" y="305" width="155" height="30" fill="#e8c4bd" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8c4bd</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5f39c0</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8883a7" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8883a7</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.70</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c29b79" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29b79</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.21</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8f6541" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f6541</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d26e87" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d26e87</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e8c4bd" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8c4bd</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
   </g>
   <g transform="translate(0,8468)">
@@ -2623,14 +2811,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#403c4d" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#403c4d</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#bc6275" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bc6275" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc6275</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
-    <rect x="330" y="305" width="310" height="30" fill="#8a8065" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a8065</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc6275</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8a8065" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a8065</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#3d7863" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d7863</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.59</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#98af9f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#98af9f</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#918faf" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#918faf</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.80</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#625d70" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#625d70</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.97</text>
   </g>
   <g transform="translate(0,8820)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Escoffier</text>
@@ -2734,10 +2938,10 @@
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac7241</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.36</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dfba8f" rx="3"/>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#eedcd2" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dfba8f</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.92</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#eedcd2</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2085b9" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#2085b9</text>
@@ -2836,21 +3040,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#b46c44" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b46c44</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#6287c0" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6287c0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6287c0</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.42</text>
-    <rect x="175" y="305" width="155" height="30" fill="#5e839c" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e839c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b46c44" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b46c44</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.32</text>
-    <rect x="485" y="305" width="155" height="30" fill="#b9a888" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b9a888</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6287c0</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.42</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5e839c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e839c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8f89" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8f89</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.36</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d8dfdd" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8dfdd</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b46c44" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b46c44</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.32</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b9a888" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b9a888</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.35</text>
   </g>
   <g transform="translate(0,9524)">
@@ -2942,13 +3154,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#4cacd4" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#4cacd4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#4798bf" rx="3"/>
-    <text x="24" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#4798bf</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
-    <rect x="330" y="305" width="310" height="30" fill="#395a70" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#395a70</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9a8c81" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#9a8c81</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.40</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8a7256" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a7256</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.43</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#69909d" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#69909d</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.58</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9cc0c3" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9cc0c3</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4798bf" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4798bf</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#395a70" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#395a70</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.62</text>
   </g>
   <g transform="translate(0,9876)">
@@ -3039,22 +3267,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#bc8f49" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bc8f49</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#8b6bc5" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#8b6bc5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b6bc5</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a5aac8" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5aac8</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
-    <rect x="330" y="305" width="155" height="30" fill="#bc8f49" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8f49</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.38</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c0976d" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0976d</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.17</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b6bc5</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a5aac8" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5aac8</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ba9092" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ba9092</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.56</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#966f6b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#966f6b</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc8f49" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8f49</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.38</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e7ccb1" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e7ccb1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.62</text>
   </g>
   <g transform="translate(0,10228)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Freminet</text>
@@ -3144,21 +3380,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#be7c76" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#be7c76</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#bc9059" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc9059</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
-    <rect x="175" y="305" width="155" height="30" fill="#967965" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#967965</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
-    <rect x="330" y="305" width="155" height="30" fill="#be7c76" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#be7c76</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
-    <rect x="485" y="305" width="155" height="30" fill="#664e48" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#664e48</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#8096aa" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#8096aa</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.53</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#95b9c2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#95b9c2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc9059" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc9059</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#967965" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#967965</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#be7c76" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#be7c76</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#664e48" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#664e48</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
   </g>
   <g transform="translate(0,10580)">
@@ -3251,21 +3495,29 @@
     <rect x="360" y="257" width="70" height="28" fill="#acac84" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#acac84</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#5b8bd8" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5b8bd8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8bd8</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
-    <rect x="175" y="305" width="155" height="30" fill="#5b7caa" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b7caa</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b96541" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b96541</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.49</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c59984" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c59984</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8bd8</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5b7caa" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b7caa</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8b8997" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b8997</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.51</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#5d5e79" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d5e79</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b96541" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b96541</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.49</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c59984" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c59984</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.97</text>
   </g>
   <g transform="translate(0,10932)">
@@ -3357,22 +3609,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#5d5a5f" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5d5a5f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#cc4c2c" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cc4c2c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc4c2c</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
-    <rect x="175" y="305" width="155" height="30" fill="#8d5a3b" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d5a3b</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.88</text>
-    <rect x="330" y="305" width="155" height="30" fill="#9baa51" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9baa51</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
-    <rect x="485" y="305" width="155" height="30" fill="#63704f" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#63704f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc4c2c</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8d5a3b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d5a3b</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.88</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9baa51" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9baa51</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#63704f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#63704f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9c9097" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9097</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.21</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#34343e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#34343e</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.74</text>
   </g>
   <g transform="translate(0,11284)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ganyu</text>
@@ -3577,14 +3837,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#434e4c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#434e4c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#bc6c56" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#a38059" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc6c56</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
-    <rect x="330" y="305" width="310" height="30" fill="#a38059" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a38059</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.33</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#a38059</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e2ceb8" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2ceb8</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#589ba7" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#589ba7</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.13</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4a626f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4a626f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.92</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#abafa6" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#abafa6</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.00</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#434e4c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#434e4c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
   </g>
   <g transform="translate(0,11988)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">HuTao</text>
@@ -3674,14 +3950,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#8e7ca5" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#8e7ca5</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#d04632" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d04632" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d04632</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
-    <rect x="330" y="305" width="310" height="30" fill="#926661" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926661</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d04632</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#926661" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926661</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ddb28f" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ddb28f</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.23</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a99e8d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e8d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.50</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8e7ca5" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e7ca5</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.91</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6e5969" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6e5969</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.99</text>
   </g>
   <g transform="translate(0,12340)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ifa</text>
@@ -3772,22 +4064,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#384148" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#384148</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c07030" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c07030" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07030</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.88</text>
-    <rect x="175" y="305" width="155" height="30" fill="#d4a794" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4a794</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.46</text>
-    <rect x="330" y="305" width="155" height="30" fill="#47b8ad" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#47b8ad</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
-    <rect x="485" y="305" width="155" height="30" fill="#457475" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#457475</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07030</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.88</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#d4a794" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4a794</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.46</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#47b8ad" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#47b8ad</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#457475" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#457475</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7f909e" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f909e</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.49</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d3d3dd" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d3d3dd</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
   </g>
   <g transform="translate(0,12692)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jean</text>
@@ -3885,14 +4185,14 @@
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a98b5</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bf9653" rx="3"/>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#96846a" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf9653</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.19</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#96846a" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#96846a</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#decdba" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#96846a</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.53</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#decdba</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.64</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bf7c5c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf7c5c</text>
@@ -3991,22 +4291,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#a29cb4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#a29cb4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c47b2c" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#c47b2c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47b2c</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.91</text>
-    <rect x="175" y="305" width="155" height="30" fill="#ae8b67" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae8b67</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.88</text>
-    <rect x="330" y="305" width="155" height="30" fill="#35cbdb" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#35cbdb</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
-    <rect x="485" y="305" width="155" height="30" fill="#437567" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437567</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.17</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47b2c</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.91</text>
+    <rect x="144" y="305" width="124" height="30" fill="#ae8b67" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae8b67</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.88</text>
+    <rect x="268" y="305" width="124" height="30" fill="#35cbdb" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#35cbdb</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="392" y="305" width="124" height="30" fill="#437567" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437567</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.17</text>
+    <rect x="516" y="305" width="124" height="30" fill="#a29cb4" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#a29cb4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.19</text>
   </g>
   <g transform="translate(0,13396)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kaeya</text>
@@ -4097,22 +4401,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#39444b" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#39444b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#6d7fbc" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6d7fbc" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d7fbc</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
-    <rect x="175" y="305" width="155" height="30" fill="#b9c5e2" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b9c5e2</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
-    <rect x="330" y="305" width="155" height="30" fill="#a76453" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a76453</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.92</text>
-    <rect x="485" y="305" width="155" height="30" fill="#736464" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#736464</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.89</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d7fbc</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b9c5e2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b9c5e2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b48062" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48062</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#736464" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#736464</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.89</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#58646b" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#58646b</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.10</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#39444b" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#39444b</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
   </g>
   <g transform="translate(0,13748)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KamisatoAyaka</text>
@@ -4224,10 +4536,10 @@
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c69f5d</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.02</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b1a45e" rx="3"/>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e2ded8" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1a45e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2ded8</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
   </g>
   <g transform="translate(0,14100)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KamisatoAyato</text>
@@ -4319,21 +4631,29 @@
     <rect x="430" y="257" width="70" height="28" fill="#30547c" rx="2"/>
     <text x="465" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#30547c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#5346ac" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5346ac" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5346ac</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.24</text>
-    <rect x="175" y="305" width="155" height="30" fill="#887a94" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#887a94</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.82</text>
-    <rect x="330" y="305" width="155" height="30" fill="#6185b2" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6185b2</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.95</text>
-    <rect x="485" y="305" width="155" height="30" fill="#8fb1cf" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8fb1cf</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5346ac</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.24</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#887a94" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#887a94</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.82</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b69e77" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69e77</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.72</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#846c4b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#846c4b</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.44</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6185b2" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6185b2</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.95</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8fb1cf" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8fb1cf</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.76</text>
   </g>
   <g transform="translate(0,14452)">
@@ -4426,22 +4746,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#26364a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#26364a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c32119" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c32119" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c32119</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.24</text>
-    <rect x="175" y="305" width="155" height="30" fill="#99644e" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#99644e</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
-    <rect x="330" y="305" width="155" height="30" fill="#2e577f" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e577f</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.99</text>
-    <rect x="485" y="305" width="155" height="30" fill="#6d83a1" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d83a1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.29</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c32119</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.24</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e2cdb1" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2cdb1</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#92aba4" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#92aba4</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#59796c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#59796c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.08</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6d83a1" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d83a1</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.27</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2e577f" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e577f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.17</text>
   </g>
   <g transform="translate(0,14804)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kazuha</text>
@@ -4533,14 +4861,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#414c3f" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#414c3f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c23723" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c23723" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23723</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.16</text>
-    <rect x="330" y="305" width="310" height="30" fill="#c08161" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08161</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23723</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.16</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c08161" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08161</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#90cfc3" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#90cfc3</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.05</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#869394" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#869394</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.61</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#587260" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#587260</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.43</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#414c3f" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#414c3f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
   </g>
   <g transform="translate(0,15156)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Keqing</text>
@@ -4631,22 +4975,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#bab08c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bab08c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#8989d1" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#8989d1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8989d1</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
-    <rect x="175" y="305" width="155" height="30" fill="#71689e" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71689e</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
-    <rect x="330" y="305" width="155" height="30" fill="#cd6395" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd6395</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
-    <rect x="485" y="305" width="155" height="30" fill="#9e899c" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e899c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#8989d1</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#71689e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71689e</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd6395" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd6395</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9e899c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e899c</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#785449" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#785449</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.76</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c99987" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c99987</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
   </g>
   <g transform="translate(0,15508)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kinich</text>
@@ -4745,14 +5097,14 @@
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a0815d</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#74bea0" rx="3"/>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#437f7e" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#74bea0</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.75</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#437f7e" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437f7e</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.37</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#275b63" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437f7e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.10</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#275b63</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3e5dac" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3e5dac</text>
@@ -4850,10 +5202,10 @@
     <rect x="220" y="257" width="70" height="28" fill="#347646" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#347646</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9c753d" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bb996c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c753d</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb996c</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.05</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a58a82" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a58a82</text>
@@ -4862,18 +5214,18 @@
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#2babb7</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#1c8ba9" rx="3"/>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#2b3540" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#1c8ba9</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.73</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#347646" rx="3"/>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b3540</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7d7e79" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#347646</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.69</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7d7e79" rx="3"/>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d7e79</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.76</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b3b6ab" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d7e79</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.16</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3b6ab</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.10</text>
   </g>
   <g transform="translate(0,16212)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Klee</text>
@@ -4964,14 +5316,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#5c4454" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5c4454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#dc4122" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#dc4122" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#dc4122</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b58e86" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58e86</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.96</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#dc4122</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b58e86" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58e86</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.96</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#f4e0ca" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f4e0ca</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=5.95</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#54544b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#54544b</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.37</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b6a8ae" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b6a8ae</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.70</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#908387" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#908387</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
   </g>
   <g transform="translate(0,16564)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KujouSara</text>
@@ -5062,22 +5430,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#c7c4c5" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c7c4c5</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#cba759" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cba759" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba759</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.31</text>
-    <rect x="175" y="305" width="155" height="30" fill="#c5ac91" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c5ac91</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.24</text>
-    <rect x="330" y="305" width="155" height="30" fill="#64389c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#64389c</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.13</text>
-    <rect x="485" y="305" width="155" height="30" fill="#888695" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#888695</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.93</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba759</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.31</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c5ac91" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c5ac91</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.24</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#64389c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#64389c</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.13</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#888695" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#888695</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.93</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8d6862" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d6862</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.72</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c7c4c5" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7c4c5</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.26</text>
   </g>
   <g transform="translate(0,16916)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KukiShinobu</text>
@@ -5167,22 +5543,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#bc683f" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bc683f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#bb4d77" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bb4d77" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bb4d77</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
-    <rect x="175" y="305" width="155" height="30" fill="#c38097" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c38097</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.16</text>
-    <rect x="330" y="305" width="155" height="30" fill="#bc683f" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc683f</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
-    <rect x="485" y="305" width="155" height="30" fill="#b89475" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89475</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.46</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bb4d77</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c38097" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c38097</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.16</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9db37e" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9db37e</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.64</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#5c7553" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c7553</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.71</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc683f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc683f</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#ded1b8" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ded1b8</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
   </g>
   <g transform="translate(0,17268)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lansan</text>
@@ -5274,18 +5658,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#382ca8" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#382ca8</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#c17329" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c17329" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c17329</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
-    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#a78f86" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78f86</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.42</text>
-    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#866ee2" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c17329</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a78f86" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78f86</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.42</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bbacb5" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bbacb5</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.28</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#685b5f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#685b5f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#866ee2" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="536.6666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#866ee2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.34</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#866ee2</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.34</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3b2b6f" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b2b6f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.61</text>
   </g>
   <g transform="translate(0,17620)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lanyan</text>
@@ -5377,21 +5773,29 @@
     <rect x="360" y="257" width="70" height="28" fill="#c2b0bd" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#c2b0bd</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#339ba4" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#339ba4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#339ba4</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
-    <rect x="175" y="305" width="155" height="30" fill="#517677" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#517677</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
-    <rect x="330" y="305" width="155" height="30" fill="#bca068" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bca068</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.81</text>
-    <rect x="485" y="305" width="155" height="30" fill="#d1b2a5" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1b2a5</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#339ba4</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#517677" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#517677</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7192a7" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7192a7</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#96b7c3" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#96b7c3</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.00</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc8476" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8476</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.00</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d1b2a5" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1b2a5</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
   </g>
   <g transform="translate(0,17972)">
@@ -5483,22 +5887,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#241c25" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#241c25</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#435c9f" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#7197c4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#435c9f</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.31</text>
-    <rect x="175" y="305" width="155" height="30" fill="#7197c4" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7197c4</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.58</text>
-    <rect x="330" y="305" width="155" height="30" fill="#ae4e1c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae4e1c</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.43</text>
-    <rect x="485" y="305" width="155" height="30" fill="#8b786b" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b786b</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.92</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#7197c4</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.36</text>
+    <rect x="144" y="305" width="124" height="30" fill="#90b8d7" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#90b8d7</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.38</text>
+    <rect x="268" y="305" width="124" height="30" fill="#ae4e1c" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae4e1c</text>
+    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.43</text>
+    <rect x="392" y="305" width="124" height="30" fill="#8b786b" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b786b</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.92</text>
+    <rect x="516" y="305" width="124" height="30" fill="#241c25" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#241c25</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=4.85</text>
   </g>
   <g transform="translate(0,18324)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lynette</text>
@@ -5589,22 +5997,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#868a85" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#868a85</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#34a5bd" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#34a5bd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a5bd</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
-    <rect x="175" y="305" width="155" height="30" fill="#41686c" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#41686c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
-    <rect x="330" y="305" width="155" height="30" fill="#ac6c34" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c34</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.26</text>
-    <rect x="485" y="305" width="155" height="30" fill="#82716a" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#82716a</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.23</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a5bd</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
+    <rect x="144" y="305" width="124" height="30" fill="#41686c" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#41686c</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="268" y="305" width="124" height="30" fill="#ac6c34" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c34</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.26</text>
+    <rect x="392" y="305" width="124" height="30" fill="#82716a" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#82716a</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.23</text>
+    <rect x="516" y="305" width="124" height="30" fill="#868a85" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#868a85</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.00</text>
   </g>
   <g transform="translate(0,18676)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lyney</text>
@@ -5695,22 +6107,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#8277a2" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8277a2</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#af7159" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#af7159" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#af7159</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.06</text>
-    <rect x="175" y="305" width="155" height="30" fill="#886e68" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#886e68</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.39</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b54672" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54672</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
-    <rect x="485" y="305" width="155" height="30" fill="#841536" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#841536</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.00</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#af7159</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.06</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#886e68" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#886e68</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.39</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b54672" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54672</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#64353a" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#64353a</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.58</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8277a2" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8277a2</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.67</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#412d4c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#412d4c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.82</text>
   </g>
   <g transform="translate(0,19028)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mavuika</text>
@@ -5799,22 +6219,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#241c24" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#241c24</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c85a2f" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#c85a2f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c85a2f</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
-    <rect x="175" y="305" width="155" height="30" fill="#bc4b2a" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc4b2a</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.92</text>
-    <rect x="330" y="305" width="155" height="30" fill="#acac04" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#acac04</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.92</text>
-    <rect x="485" y="305" width="155" height="30" fill="#b09784" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b09784</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#c85a2f</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="144" y="305" width="124" height="30" fill="#433d3c" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#433d3c</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.82</text>
+    <rect x="268" y="305" width="124" height="30" fill="#acac04" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#acac04</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.92</text>
+    <rect x="392" y="305" width="124" height="30" fill="#b09784" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b09784</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <rect x="516" y="305" width="124" height="30" fill="#241c24" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#241c24</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=4.82</text>
   </g>
   <g transform="translate(0,19380)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mika</text>
@@ -5906,22 +6330,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#494c47" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#494c47</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#6b84b7" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6b84b7" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b84b7</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
-    <rect x="175" y="305" width="155" height="30" fill="#b2a1c0" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b2a1c0</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
-    <rect x="330" y="305" width="155" height="30" fill="#ac6c14" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c14</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
-    <rect x="485" y="305" width="155" height="30" fill="#887b6d" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#887b6d</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b84b7</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b2a1c0" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b2a1c0</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac6c14" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c14</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#887b6d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#887b6d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#dce2e1" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#dce2e1</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=5.55</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#494c47" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#494c47</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.12</text>
   </g>
   <g transform="translate(0,19732)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mona</text>
@@ -6013,22 +6445,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#756f6a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#756f6a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7475bd" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7475bd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7475bd</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.33</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a1a0ab" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a1a0ab</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b54450" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54450</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
-    <rect x="485" y="305" width="155" height="30" fill="#9c5052" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c5052</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7475bd</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.33</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a1a0ab" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a1a0ab</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b54450" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54450</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9c5052" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c5052</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#be8f7b" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8f7b</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#edd7c1" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#edd7c1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.53</text>
   </g>
   <g transform="translate(0,20084)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mualani</text>
@@ -6132,10 +6572,10 @@
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b94639</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c67ead" rx="3"/>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e0d9d4" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67ead</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0d9d4</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#eab432" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#eab432</text>
@@ -6233,22 +6673,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#8c90a4" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#8c90a4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#777c41" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#aa9c72" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#777c41</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.94</text>
-    <rect x="175" y="305" width="155" height="30" fill="#aa9c72" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#aa9c72</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
-    <rect x="330" y="305" width="155" height="30" fill="#549468" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#549468</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.18</text>
-    <rect x="485" y="305" width="155" height="30" fill="#7a9a7c" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a9a7c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.73</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#aa9c72</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e5dcc7" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e5dcc7</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.37</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7a9a7c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a9a7c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a7bfa6" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a7bfa6</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#97929b" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#97929b</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.11</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c90a4" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c90a4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
   </g>
   <g transform="translate(0,20788)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Navia</text>
@@ -6339,21 +6787,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#51647e" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#51647e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#be8641" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#be8641" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8641</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.79</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a4855e" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4855e</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
-    <rect x="330" y="305" width="155" height="30" fill="#2d66d2" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d66d2</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.11</text>
-    <rect x="485" y="305" width="155" height="30" fill="#434e6e" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#434e6e</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8641</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.79</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a4855e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4855e</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#3b3533" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b3533</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.25</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#120c0c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#120c0c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.82</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2d66d2" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d66d2</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.11</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#434e6e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#434e6e</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.44</text>
   </g>
   <g transform="translate(0,21140)">
@@ -6450,10 +6906,10 @@
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3078c4</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.72</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#3a5b8c" rx="3"/>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#1d243f" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a5b8c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.48</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1d243f</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.54</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9c541c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c541c</text>
@@ -6559,21 +7015,29 @@
     <rect x="360" y="257" width="70" height="28" fill="#8a4454" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8a4454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#348dbb" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#348dbb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#348dbb</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.40</text>
-    <rect x="175" y="305" width="155" height="30" fill="#658aa2" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#658aa2</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.21</text>
-    <rect x="330" y="305" width="155" height="30" fill="#c75f3f" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75f3f</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c4715d" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c4715d</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#348dbb</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.40</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#658aa2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#658aa2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.21</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c79b70" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c79b70</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.13</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#ebe1d6" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#ebe1d6</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c75f3f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75f3f</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c4715d" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c4715d</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
   </g>
   <g transform="translate(0,21844)">
@@ -6664,6 +7128,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#474454" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#474454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b08f74" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08f74</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#86766c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#86766c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#835f35" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#835f35</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.57</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f5e8d5" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f5e8d5</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4c4c4f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c4c4f</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.68</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#474454" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#474454</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.31</text>
   </g>
   <g transform="translate(0,22196)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Noelle</text>
@@ -6754,13 +7242,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#d44c7c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#d44c7c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#d02c64" rx="3"/>
-    <text x="24" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d02c64</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
-    <rect x="330" y="305" width="310" height="30" fill="#89264b" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#89264b</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ada4ad" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ada4ad</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.77</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#847f92" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#847f92</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#987862" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#987862</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.46</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#735747" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#735747</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.36</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d02c64" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d02c64</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#89264b" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#89264b</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
   </g>
   <g transform="translate(0,22548)">
@@ -6853,25 +7357,29 @@
     <rect x="150" y="257" width="70" height="28" fill="#2c9ca4" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#2c9ca4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#3b68d1" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3b68d1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b68d1</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.01</text>
-    <rect x="144" y="305" width="124" height="30" fill="#a999a0" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#a999a0</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.44</text>
-    <rect x="268" y="305" width="124" height="30" fill="#d9bb57" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9bb57</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.98</text>
-    <rect x="392" y="305" width="124" height="30" fill="#57bcf2" rx="3"/>
-    <text x="396" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#57bcf2</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.18</text>
-    <rect x="516" y="305" width="124" height="30" fill="#2c9ca4" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#2c9ca4</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b68d1</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.01</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a999a0" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a999a0</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.44</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d9bb57" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9bb57</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.98</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e7e1dd" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e7e1dd</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.95</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#57bcf2" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#57bcf2</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.18</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2c9ca4" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#2c9ca4</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
   </g>
   <g transform="translate(0,22900)">
@@ -6964,22 +7472,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#e8d691" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e8d691</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7879b9" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7879b9" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7879b9</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
-    <rect x="175" y="305" width="155" height="30" fill="#9babe1" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9babe1</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b56a95" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b56a95</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.73</text>
-    <rect x="485" y="305" width="155" height="30" fill="#886182" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#886182</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.93</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7879b9</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9babe1" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9babe1</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b56a95" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b56a95</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.73</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#886182" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#886182</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.93</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b0a69f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b0a69f</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.74</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#73644e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#73644e</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
   </g>
   <g transform="translate(0,23252)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">RaidenShogun</text>
@@ -7070,22 +7586,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#b89269" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#b89269</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#957aca" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#957aca" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#957aca</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
-    <rect x="175" y="305" width="155" height="30" fill="#aba4c8" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#aba4c8</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
-    <rect x="330" y="305" width="155" height="30" fill="#bc2462" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc2462</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
-    <rect x="485" y="305" width="155" height="30" fill="#917790" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#917790</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#957aca</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#aba4c8" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#aba4c8</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc2462" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc2462</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#917790" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#917790</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c8a592" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c8a592</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b89269" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89269</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
   </g>
   <g transform="translate(0,23604)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Razor</text>
@@ -7176,21 +7700,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#e0384c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e0384c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#b3b45c" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9d8763" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3b45c</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.09</text>
-    <rect x="175" y="305" width="155" height="30" fill="#9d8763" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8763</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.47</text>
-    <rect x="330" y="305" width="155" height="30" fill="#e0384c" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0384c</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
-    <rect x="485" y="305" width="155" height="30" fill="#584741" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584741</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8763</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.58</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b0b69b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b0b69b</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.86</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9ba4b7" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9ba4b7</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.25</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6b6d81" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6b6d81</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e0384c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0384c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#584741" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584741</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.36</text>
   </g>
   <g transform="translate(0,23956)">
@@ -7282,22 +7814,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#a08c9c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a08c9c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c22c41" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c22c41" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c22c41</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
-    <rect x="175" y="305" width="155" height="30" fill="#987677" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#987677</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
-    <rect x="330" y="305" width="155" height="30" fill="#c07451" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07451</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.53</text>
-    <rect x="485" y="305" width="155" height="30" fill="#d1beb6" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1beb6</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c22c41</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#987677" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#987677</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c07451" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07451</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.53</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d1beb6" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1beb6</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a08c9c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a08c9c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.42</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#1c1118" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c1118</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.01</text>
   </g>
   <g transform="translate(0,24308)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">SangonomiyaKokomi</text>
@@ -7511,10 +8051,10 @@
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a39880</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.91</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c5938" rx="3"/>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#986b57" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c5938</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.62</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#986b57</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.83</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#655958" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#655958</text>
@@ -7523,10 +8063,10 @@
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#354a7c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.92</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#444474" rx="3"/>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2a232f" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#444474</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2a232f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.48</text>
   </g>
   <g transform="translate(0,25012)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sethos</text>
@@ -7731,14 +8271,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#a4a484" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a4a484</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#d23e35" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d23e35</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7393ab" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7393ab</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#86b8ca" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b8ca</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.38</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d23e35" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d23e35</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
-    <rect x="330" y="305" width="310" height="30" fill="#826c66" rx="3"/>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#826c66" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826c66</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.25</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826c66</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.25</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a4a484" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a484</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.31</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d3d5d2" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d3d5d2</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
   </g>
   <g transform="translate(0,25716)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">ShikanoinHeizou</text>
@@ -7830,21 +8386,29 @@
     <rect x="150" y="257" width="70" height="28" fill="#158480" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#158480</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#b17135" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b17135" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b17135</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
-    <rect x="175" y="305" width="155" height="30" fill="#957e79" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#957e79</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.03</text>
-    <rect x="330" y="305" width="155" height="30" fill="#158480" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#158480</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.81</text>
-    <rect x="485" y="305" width="155" height="30" fill="#a9aea8" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a9aea8</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b17135</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#957e79" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#957e79</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.03</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9d94a4" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d94a4</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.27</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3f3335" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3f3335</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#158480" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#158480</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.81</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a9aea8" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a9aea8</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.98</text>
   </g>
   <g transform="translate(0,26068)">
@@ -7935,22 +8499,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#e8ceb8" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e8ceb8</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7153d0" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7153d0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7153d0</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.11</text>
-    <rect x="175" y="305" width="155" height="30" fill="#7ea9c4" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ea9c4</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
-    <rect x="330" y="305" width="155" height="30" fill="#d97f8d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d97f8d</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
-    <rect x="485" y="305" width="155" height="30" fill="#e5abbf" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e5abbf</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7153d0</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.11</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7ea9c4" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ea9c4</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d97f8d" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d97f8d</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dac8e1" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dac8e1</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.01</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9f7558" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f7558</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d2af91" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d2af91</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.97</text>
   </g>
   <g transform="translate(0,26420)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Skirk</text>
@@ -8042,18 +8614,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#32b2f1" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#32b2f1</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#5e7dd7" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5e7dd7" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e7dd7</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
-    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#9899bb" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#9899bb</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
-    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#32b2f1" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e7dd7</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9899bb" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9899bb</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ad9996" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ad9996</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.92</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#88715d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#88715d</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#32b2f1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="536.6666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#32b2f1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.72</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#32b2f1</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.72</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c3e4fa" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3e4fa</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
   </g>
   <g transform="translate(0,26772)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sucrose</text>
@@ -8144,21 +8728,29 @@
     <rect x="360" y="257" width="70" height="28" fill="#34a4ac" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#34a4ac</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#d4947c" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d4947c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4947c</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.84</text>
-    <rect x="175" y="305" width="155" height="30" fill="#978066" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
-    <rect x="330" y="305" width="155" height="30" fill="#34a4ac" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a4ac</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
-    <rect x="485" y="305" width="155" height="30" fill="#9abfb4" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9abfb4</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4947c</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.84</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#978066" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9097a0" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9097a0</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.09</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4e6980" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e6980</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.27</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#34a4ac" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a4ac</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9abfb4" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9abfb4</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.69</text>
   </g>
   <g transform="translate(0,27124)">
@@ -8271,10 +8863,10 @@
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8443</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.98</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b4aca4" rx="3"/>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e1d7c8" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4aca4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1d7c8</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
   </g>
   <g transform="translate(0,27476)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Thoma</text>
@@ -8385,10 +8977,10 @@
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9172b0</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#585560" rx="3"/>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#374649" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#585560</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.58</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#374649</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
   </g>
   <g transform="translate(0,27828)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Tighnari</text>
@@ -8593,21 +9185,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#599195" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#599195</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c86e67" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c86e67" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c86e67</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
-    <rect x="175" y="305" width="155" height="30" fill="#baa99e" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#baa99e</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
-    <rect x="330" y="305" width="155" height="30" fill="#51c7b4" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#51c7b4</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.46</text>
-    <rect x="485" y="305" width="155" height="30" fill="#8baa98" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8baa98</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c86e67</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e9c7b6" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e9c7b6</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.70</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cbb583" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cbb583</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.28</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b59764" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b59764</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#51c7b4" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#51c7b4</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.46</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8baa98" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8baa98</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.60</text>
   </g>
   <g transform="translate(0,28532)">
@@ -8699,21 +9299,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#44477c" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#44477c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#33a18c" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#33a18c</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
-    <rect x="175" y="305" width="155" height="30" fill="#8ba0a6" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8ba0a6</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
-    <rect x="330" y="305" width="155" height="30" fill="#1075a9" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1075a9</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
-    <rect x="485" y="305" width="155" height="30" fill="#7a8289" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a8289</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#968664" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#968664</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.02</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b5a088" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5a088</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#33a18c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#33a18c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8ba0a6" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8ba0a6</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#1075a9" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1075a9</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7a8289" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a8289</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.33</text>
   </g>
   <g transform="translate(0,28884)">
@@ -8919,14 +9527,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#595c5b" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#595c5b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#b52438" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52438</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.84</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b48375" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48375</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.64</text>
+    <rect x="20" y="305" width="124" height="30" fill="#8b8a9c" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b8a9c</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.39</text>
+    <rect x="144" y="305" width="124" height="30" fill="#9197a6" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#9197a6</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.62</text>
+    <rect x="268" y="305" width="124" height="30" fill="#b52438" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52438</text>
+    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.84</text>
+    <rect x="392" y="305" width="124" height="30" fill="#b48375" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48375</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.64</text>
+    <rect x="516" y="305" width="124" height="30" fill="#595c5b" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#595c5b</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.99</text>
   </g>
   <g transform="translate(0,29588)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xiangling</text>
@@ -9026,14 +9646,14 @@
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#cf9f78</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#46699e" rx="3"/>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#394b73" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#46699e</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.62</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#394b73" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#394b73</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.66</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9cb4d4" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#394b73</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9cb4d4</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4c9464" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9464</text>
@@ -9131,22 +9751,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#070b0f" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#070b0f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c75531" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c75531" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75531</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.97</text>
-    <rect x="175" y="305" width="155" height="30" fill="#856c59" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#856c59</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
-    <rect x="330" y="305" width="155" height="30" fill="#6ca46c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca46c</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.42</text>
-    <rect x="485" y="305" width="155" height="30" fill="#7ac1b0" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ac1b0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75531</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.97</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#856c59" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#856c59</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6ca46c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca46c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.42</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7ac1b0" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ac1b0</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#458da1" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#458da1</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3d556d" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d556d</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
   </g>
   <g transform="translate(0,30292)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xiao</text>
@@ -9245,14 +9873,14 @@
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b787f</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.86</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6ecba5" rx="3"/>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#518b8c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ecba5</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#518b8c" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#518b8c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.60</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3a6561" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#518b8c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.37</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a6561</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b98740" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b98740</text>
@@ -9463,14 +10091,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#7f96b7" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#7f96b7</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c25e13" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c25e13" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c25e13</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.91</text>
-    <rect x="330" y="305" width="310" height="30" fill="#978066" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.02</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c25e13</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.91</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#978066" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.02</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#597b8d" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#597b8d</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.68</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#42657c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#42657c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7f96b7" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f96b7</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.78</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#1c2028" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c2028</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
   </g>
   <g transform="translate(0,31348)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xinyan</text>
@@ -9562,14 +10206,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#3c3444" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3c3444</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#df5b38" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#df5b38" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#df5b38</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
-    <rect x="330" y="305" width="310" height="30" fill="#c2a088" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a088</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#df5b38</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c2a088" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a088</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#fcc841" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#fcc841</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.09</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#ede7d7" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#ede7d7</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#261719" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#261719</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=4.82</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3c3444" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c3444</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.98</text>
   </g>
   <g transform="translate(0,31700)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">YaeMiko</text>
@@ -9661,22 +10321,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#b4c4c4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#b4c4c4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#e3524d" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#e3524d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3524d</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
-    <rect x="175" y="305" width="155" height="30" fill="#d9a095" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9a095</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
-    <rect x="330" y="305" width="155" height="30" fill="#534ba1" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#534ba1</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.93</text>
-    <rect x="485" y="305" width="155" height="30" fill="#5c6494" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6494</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.65</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3524d</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="144" y="305" width="124" height="30" fill="#d9a095" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9a095</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
+    <rect x="268" y="305" width="124" height="30" fill="#534ba1" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#534ba1</text>
+    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.93</text>
+    <rect x="392" y="305" width="124" height="30" fill="#402838" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#402838</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.92</text>
+    <rect x="516" y="305" width="124" height="30" fill="#b4c4c4" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4c4c4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.31</text>
   </g>
   <g transform="translate(0,32052)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yanfei</text>
@@ -9767,21 +10431,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#44848c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#44848c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#b0425c" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0425c</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a5939d" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5939d</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.76</text>
-    <rect x="330" y="305" width="155" height="30" fill="#3da792" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da792</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
-    <rect x="485" y="305" width="155" height="30" fill="#307066" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#307066</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b58d69" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58d69</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.03</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e1baad" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1baad</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b0425c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0425c</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a5939d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5939d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.76</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3da792" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da792</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#307066" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#307066</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.61</text>
   </g>
   <g transform="translate(0,32404)">
@@ -9873,22 +10545,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#94a4c4" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#94a4c4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#eb9d1b" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#eb9d1b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#eb9d1b</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.82</text>
-    <rect x="175" y="305" width="155" height="30" fill="#9c9551" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9551</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
-    <rect x="330" y="305" width="155" height="30" fill="#a27243" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a27243</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.48</text>
-    <rect x="485" y="305" width="155" height="30" fill="#874f33" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#874f33</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.75</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#eb9d1b</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.82</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9c9551" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9551</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a27243" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a27243</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.48</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#402b24" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#402b24</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.88</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#61647c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#61647c</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.73</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#94a4c4" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#94a4c4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.78</text>
   </g>
   <g transform="translate(0,32756)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yelan</text>
@@ -9978,21 +10658,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#ac6454" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ac6454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#5665be" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5665be" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5665be</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.66</text>
-    <rect x="175" y="305" width="155" height="30" fill="#91a4c8" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#91a4c8</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.42</text>
-    <rect x="330" y="305" width="155" height="30" fill="#ac6454" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6454</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c7ac97" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7ac97</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5665be</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.66</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#91a4c8" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#91a4c8</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.42</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac8f95" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8f95</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.71</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#766363" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#766363</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.98</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ac6454" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6454</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c7ac97" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7ac97</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.28</text>
   </g>
   <g transform="translate(0,33108)">
@@ -10097,18 +10785,18 @@
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d19c70</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f3c581" rx="3"/>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f2dac1" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f3c581</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f2dac1</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#495494" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#495494</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#99bcbe" rx="3"/>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#404561" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#99bcbe</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.25</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#404561</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.37</text>
   </g>
   <g transform="translate(0,33460)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">YumemizukiMizuki</text>
@@ -10200,22 +10888,30 @@
     <rect x="360" y="257" width="70" height="28" fill="#e3bdb2" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#e3bdb2</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7941cf" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7941cf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7941cf</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a96faf" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a96faf</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
-    <rect x="330" y="305" width="155" height="30" fill="#4484cc" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#4484cc</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.65</text>
-    <rect x="485" y="305" width="155" height="30" fill="#9facc8" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9facc8</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.04</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7941cf</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a96faf" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a96faf</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6a79aa" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6a79aa</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.77</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9facc8" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9facc8</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.04</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#caa685" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#caa685</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.36</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8f6c55" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f6c55</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.25</text>
   </g>
   <g transform="translate(0,33812)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yunjin</text>
@@ -10306,21 +11002,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#716d66" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#716d66</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c43e4e" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c43e4e</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
-    <rect x="175" y="305" width="155" height="30" fill="#915f6f" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#915f6f</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
-    <rect x="330" y="305" width="155" height="30" fill="#e08d3c" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e08d3c</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c2a082" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a082</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7a91b3" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a91b3</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#86b3ca" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b3ca</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c43e4e" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c43e4e</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#915f6f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#915f6f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e08d3c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e08d3c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c2a082" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a082</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
   </g>
   <g transform="translate(0,34164)">
@@ -10411,17 +11115,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#413d57" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#413d57</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#a47538" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#a47538" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a47538</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.17</text>
-    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#b8a082" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#b8a082</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
-    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#a04210" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="536.6666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a04210</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#a47538</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.17</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b8a082" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b8a082</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a04210" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a04210</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4e3425" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e3425</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.56</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8d8791" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8d8791</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.29</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9294a5" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9294a5</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
   </g>
 </svg>

--- a/debug/palettes/colorthief/genshin.svg
+++ b/debug/palettes/colorthief/genshin.svg
@@ -88,30 +88,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#ac8b8e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ac8b8e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#656db5" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#656db5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#656db5</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4c4f84" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c4f84</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b6440c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6440c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bb8e6e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb8e6e</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ac8b8e" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8b8e</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c736f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c736f</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#656db5</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
+    <rect x="175" y="305" width="155" height="30" fill="#9da5af" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9da5af</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b6440c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6440c</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.71</text>
+    <rect x="485" y="305" width="155" height="30" fill="#d7cabf" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7cabf</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.54</text>
   </g>
   <g transform="translate(0,372)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Alhaitham</text>
@@ -205,27 +197,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3586b6" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3586b6</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.26</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#33595a" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#33595a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a68c32" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a68c32</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9f7454" rx="3"/>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.66</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b7a57d" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f7454</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.05</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b7a57d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#76bb38" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#76bb38</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#62b9a9" rx="3"/>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5e8171" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#62b9a9</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e8171</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.43</text>
   </g>
   <g transform="translate(0,724)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Amber</text>
@@ -315,30 +307,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#6b616c" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6b616c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d2322a" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#d2322a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d2322a</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9f4741" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9f4741</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cba783" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba783</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#68554e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#68554e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#544956" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#544956</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.20</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9f919e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f919e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d2322a</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <rect x="330" y="305" width="310" height="30" fill="#7e6e69" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6e69</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.24</text>
   </g>
   <g transform="translate(0,1076)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">AratakiItto</text>
@@ -429,30 +405,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#333432" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#333432</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5d476f" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d476f</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9086a1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9086a1</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c34225" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c34225</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bc8365" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8365</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#da8c35" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8c35</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e6c8a1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e6c8a1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
+    <rect x="20" y="305" width="155" height="30" fill="#c34225" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c34225</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.02</text>
+    <rect x="175" y="305" width="155" height="30" fill="#82625f" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#82625f</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.71</text>
+    <rect x="330" y="305" width="155" height="30" fill="#da8c35" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8c35</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
+    <rect x="485" y="305" width="155" height="30" fill="#e6c8a1" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e6c8a1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.48</text>
   </g>
   <g transform="translate(0,1428)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Arlecchino</text>
@@ -544,26 +512,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#aca074" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#aca074</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#565b65" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#565b65</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.16</text>
-    <rect x="144" y="305" width="124" height="30" fill="#8d929d" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#8d929d</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="268" y="305" width="124" height="30" fill="#c01415" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01415</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
-    <rect x="392" y="305" width="124" height="30" fill="#894e50" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#894e50</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="516" y="305" width="124" height="30" fill="#aca074" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#aca074</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.89</text>
+    <rect x="20" y="305" width="310" height="30" fill="#c01415" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01415</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="330" y="305" width="310" height="30" fill="#cc7d75" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc7d75</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.97</text>
   </g>
   <g transform="translate(0,1780)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Baizhu</text>
@@ -653,30 +609,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#8e896e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8e896e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2c7bba" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#5954bc" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#2c7bba</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7d669c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d669c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#18beae" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#18beae</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#509ca5" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#509ca5</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#957944" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#957944</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8e896e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e896e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5954bc</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
+    <rect x="175" y="305" width="155" height="30" fill="#9eb0c4" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9eb0c4</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.33</text>
+    <rect x="330" y="305" width="155" height="30" fill="#18beae" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#18beae</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="485" y="305" width="155" height="30" fill="#509ca5" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#509ca5</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
   </g>
   <g transform="translate(0,2132)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Barbara</text>
@@ -768,26 +716,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#746f70" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#746f70</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#3696bf" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#3696bf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#3696bf</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="144" y="305" width="124" height="30" fill="#415d8e" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#415d8e</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="268" y="305" width="124" height="30" fill="#cc8e4a" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc8e4a</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="392" y="305" width="124" height="30" fill="#bca474" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#bca474</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="516" y="305" width="124" height="30" fill="#746f70" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#746f70</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.25</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#3696bf</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
+    <rect x="175" y="305" width="155" height="30" fill="#b1b1ba" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1b1ba</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.42</text>
+    <rect x="330" y="305" width="155" height="30" fill="#ce7c59" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ce7c59</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.60</text>
+    <rect x="485" y="305" width="155" height="30" fill="#9b8778" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8778</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.18</text>
   </g>
   <g transform="translate(0,2484)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Beidou</text>
@@ -877,30 +821,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#524c43" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#524c43</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba3549" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#ba3549" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba3549</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8e5653" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8e5653</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#83acb6" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#83acb6</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9783a5" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9783a5</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ae6a5b" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae6a5b</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c19981" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c19981</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba3549</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
+    <rect x="175" y="305" width="155" height="30" fill="#b57a70" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b57a70</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="330" y="305" width="155" height="30" fill="#ae6a5b" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae6a5b</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c19981" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c19981</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.53</text>
   </g>
   <g transform="translate(0,2836)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Bennett</text>
@@ -991,30 +927,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#3d4e5b" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3d4e5b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d6942b" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#cf1308" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d6942b</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#947255" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#947255</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#343b63" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#343b63</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#444a77" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#444a77</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3d4e5b" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d4e5b</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.01</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6d7074" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d7074</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cf1308</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
+    <rect x="330" y="305" width="310" height="30" fill="#e0c9b3" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0c9b3</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
   </g>
   <g transform="translate(0,3188)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Candace</text>
@@ -1105,30 +1025,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#32606a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#32606a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2b3d7a" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4b3c94" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b3d7a</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#635780" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b3c94</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.72</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8f7d8a" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#635780</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#805231" rx="3"/>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8f7d8a</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.92</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b47e53" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#805231</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b47e53" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47e53</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.38</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dcac8d" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47e53</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dcac8d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.76</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#1fa2c5" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#1fa2c5</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.02</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#32606a" rx="3"/>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2278ad" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#32606a</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2278ad</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
   </g>
   <g transform="translate(0,3540)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Charlotte</text>
@@ -1219,30 +1139,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#326399" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#326399</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c54e75" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c54e75" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c54e75</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a4549c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a4549c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#86704b" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#86704b</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bfaa81" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bfaa81</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#326399" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#326399</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3da5af" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da5af</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c54e75</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="175" y="305" width="155" height="30" fill="#b1787e" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1787e</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
+    <rect x="330" y="305" width="155" height="30" fill="#3da5af" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da5af</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
+    <rect x="485" y="305" width="155" height="30" fill="#747d8a" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#747d8a</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
   </g>
   <g transform="translate(0,3892)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chasca</text>
@@ -1333,26 +1245,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#44334e" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#44334e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#be483f" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#be483f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#be483f</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="144" y="305" width="124" height="30" fill="#a2947c" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2947c</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="268" y="305" width="124" height="30" fill="#3b4479" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b4479</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
-    <rect x="392" y="305" width="124" height="30" fill="#6271a8" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6271a8</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.05</text>
-    <rect x="516" y="305" width="124" height="30" fill="#44334e" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#44334e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.05</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#be483f</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.80</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a2947c" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2947c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
+    <rect x="330" y="305" width="155" height="30" fill="#6271a8" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6271a8</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
+    <rect x="485" y="305" width="155" height="30" fill="#869cb9" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#869cb9</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
   </g>
   <g transform="translate(0,4244)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chevreuse</text>
@@ -1444,30 +1352,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#b39c64" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b39c64</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#432b69" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#8862b4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#432b69</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6a5390" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8862b4</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.98</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#aaa2a8" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a5390</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#aaa2a8</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c40f50" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c40f50</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9a665f" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9a665f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c39955" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c39955</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b39c64" rx="3"/>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.16</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dac8b7" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b39c64</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dac8b7</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.70</text>
   </g>
   <g transform="translate(0,4596)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chiori</text>
@@ -1558,30 +1466,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#9587b1" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#9587b1</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba341e" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#ba341e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba341e</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.08</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#864f40" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#864f40</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd8934" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8934</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c3a38d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3a38d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9587b1" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9587b1</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.00</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#53576a" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#53576a</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba341e</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
+    <rect x="175" y="305" width="155" height="30" fill="#864f40" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#864f40</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
+    <rect x="330" y="305" width="155" height="30" fill="#cd8934" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8934</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c3a38d" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3a38d</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
   </g>
   <g transform="translate(0,4948)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chongyun</text>
@@ -1673,26 +1573,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#1d1b1d" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#1d1b1d</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#6b9dc3" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b9dc3</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="144" y="305" width="124" height="30" fill="#618aa9" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#618aa9</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.05</text>
-    <rect x="268" y="305" width="124" height="30" fill="#8a6430" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a6430</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="392" y="305" width="124" height="30" fill="#84544c" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#84544c</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="516" y="305" width="124" height="30" fill="#1d1b1d" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1d1b1d</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.49</text>
+    <rect x="20" y="305" width="310" height="30" fill="#c48464" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48464</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.24</text>
+    <rect x="330" y="305" width="310" height="30" fill="#978a7d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#978a7d</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.45</text>
   </g>
   <g transform="translate(0,5300)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Citlali</text>
@@ -1784,30 +1672,18 @@
     <rect x="150" y="257" width="70" height="28" fill="#408ca0" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#408ca0</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#423fb6" rx="3"/>
+    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#886cc3" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#423fb6</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5350aa" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5350aa</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#e3a7c0" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3a7c0</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#71554c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71554c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#408ca0" rx="3"/>
+    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#886cc3</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#785e7a" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#785e7a</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
+    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#408ca0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#408ca0</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#92e6f4" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#92e6f4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
+    <text x="536.6666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#408ca0</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.06</text>
   </g>
   <g transform="translate(0,5652)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Clorinde</text>
@@ -1899,30 +1775,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#a78356" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a78356</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2031b9" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#c45ce4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2031b9</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#575690" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#575690</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a78282" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78282</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#534647" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#534647</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a78356" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78356</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7e6b61" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6b61</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c45ce4</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <rect x="330" y="305" width="310" height="30" fill="#646c6e" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#646c6e</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
   </g>
   <g transform="translate(0,6004)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Collei</text>
@@ -2016,27 +1876,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#edbd75" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#edbd75</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#897f5c" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.68</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#be9c6a" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#897f5c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#be9c6a</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6cac3c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6cac3c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c0cb7d" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0cb7d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2859a0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2859a0</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c3484" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c3484</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
   </g>
   <g transform="translate(0,6356)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Cyno</text>
@@ -2128,30 +1988,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#cda475" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#cda475</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4464ac" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4c44ac" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4464ac</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4c44ac" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c44ac</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.24</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#978e99" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c44ac</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#978e99</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.82</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9c5f31" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c5f31</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#966b54" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#966b54</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.86</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bb8b59" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb8b59</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cda475" rx="3"/>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.46</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dbbba2" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cda475</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dbbba2</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.87</text>
   </g>
   <g transform="translate(0,6708)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Dahlia</text>
@@ -2242,30 +2102,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#444649" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#444649</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#772131" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#bd465e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#772131</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#985e5a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#985e5a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c08e6c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08e6c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b1a16c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1a16c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6e85a1" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6e85a1</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#495369" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#495369</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bd465e</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.78</text>
+    <rect x="330" y="305" width="310" height="30" fill="#c5988b" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c5988b</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
   </g>
   <g transform="translate(0,7060)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Dehya</text>
@@ -2357,30 +2201,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#a4949c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#a4949c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c71a11" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c71a11" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c71a11</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#96533d" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#96533d</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#da8b33" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8b33</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a99e84" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e84</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6d5a64" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d5a64</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a4949c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4949c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c71a11</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.26</text>
+    <rect x="175" y="305" width="155" height="30" fill="#c47958" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47958</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.05</text>
+    <rect x="330" y="305" width="155" height="30" fill="#da8b33" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8b33</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.77</text>
+    <rect x="485" y="305" width="155" height="30" fill="#a99e84" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e84</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
   </g>
   <g transform="translate(0,7412)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Diluc</text>
@@ -2470,30 +2306,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#8c8c94" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#8c8c94</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cc472d" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#cc472d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cc472d</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a17868" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a17868</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#879596" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#879596</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.19</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#545c5c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#545c5c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2b333c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b333c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.18</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8c94" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8c94</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cc472d</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.18</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b69482" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69482</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
   </g>
   <g transform="translate(0,7764)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Diona</text>
@@ -2583,30 +2403,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#276f63" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#276f63</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ad7244" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba776b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ad7244</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ba776b" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ba776b</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.38</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#dcb4a3" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ba776b</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#dcb4a3</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4c7fac" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c7fac</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#54547c" rx="3"/>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.91</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#adbcd5" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#54547c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#276f63" rx="3"/>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#adbcd5</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4c9e89" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#276f63</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c9e89" rx="3"/>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9e89</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.84</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#276f63" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9e89</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#276f63</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
   </g>
   <g transform="translate(0,8116)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Dori</text>
@@ -2698,30 +2518,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#d26e87" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#d26e87</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4625a4" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#5f39c0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4625a4</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8e649b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8e649b</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8f6541" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f6541</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c29b79" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29b79</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d26e87" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d26e87</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6e374b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6e374b</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5f39c0</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
+    <rect x="175" y="305" width="155" height="30" fill="#8883a7" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8883a7</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.70</text>
+    <rect x="330" y="305" width="155" height="30" fill="#d26e87" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d26e87</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
+    <rect x="485" y="305" width="155" height="30" fill="#e8c4bd" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8c4bd</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
   </g>
   <g transform="translate(0,8468)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Emilie</text>
@@ -2811,30 +2623,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#403c4d" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#403c4d</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c39148" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#bc6275" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c39148</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bc6275" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc6275</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#215646" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#215646</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3d7863" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d7863</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#918faf" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#918faf</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.08</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#625d70" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#625d70</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
+    <rect x="330" y="305" width="310" height="30" fill="#8a8065" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a8065</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
   </g>
   <g transform="translate(0,8820)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Escoffier</text>
@@ -2929,27 +2725,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d94b8c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d94b8c</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bf7476" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b6a4af" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf7476</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b6a4af</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac7241" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac7241</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d9a46a" rx="3"/>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.36</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dfba8f" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9a46a</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dfba8f</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.92</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2085b9" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#2085b9</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#788490" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#788490</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.49</text>
   </g>
   <g transform="translate(0,9172)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Eula</text>
@@ -3040,30 +2836,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#b46c44" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b46c44</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#0e3362" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#6287c0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0e3362</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5e839c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e839c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8f89" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8f89</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.26</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d8dfdd" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8dfdd</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.98</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b46c44" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b46c44</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#be8a62" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8a62</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6287c0</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.42</text>
+    <rect x="175" y="305" width="155" height="30" fill="#5e839c" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e839c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b46c44" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b46c44</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.32</text>
+    <rect x="485" y="305" width="155" height="30" fill="#b9a888" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b9a888</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.35</text>
   </g>
   <g transform="translate(0,9524)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Faruzan</text>
@@ -3154,30 +2942,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#4cacd4" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#4cacd4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6a493a" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a493a</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8a7256" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a7256</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#69909d" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#69909d</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9cc0c3" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9cc0c3</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4cacd4" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4cacd4</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4798bf" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4798bf</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <rect x="20" y="305" width="310" height="30" fill="#4798bf" rx="3"/>
+    <text x="24" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#4798bf</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="330" y="305" width="310" height="30" fill="#395a70" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#395a70</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.62</text>
   </g>
   <g transform="translate(0,9876)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Fischl</text>
@@ -3267,30 +3039,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#bc8f49" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bc8f49</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b574e5" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#8b6bc5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b574e5</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#614d90" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#614d90</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#724f4f" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#724f4f</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.99</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#966f6b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#966f6b</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc8f49" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8f49</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c0976d" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0976d</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b6bc5</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a5aac8" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5aac8</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
+    <rect x="330" y="305" width="155" height="30" fill="#bc8f49" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8f49</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.38</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c0976d" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0976d</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.17</text>
   </g>
   <g transform="translate(0,10228)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Freminet</text>
@@ -3380,30 +3144,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#be7c76" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#be7c76</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f507a" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f507a</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8096aa" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8096aa</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc9059" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc9059</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#967965" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#967965</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#be7c76" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#be7c76</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#664e48" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#664e48</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="20" y="305" width="155" height="30" fill="#bc9059" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc9059</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
+    <rect x="175" y="305" width="155" height="30" fill="#967965" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#967965</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
+    <rect x="330" y="305" width="155" height="30" fill="#be7c76" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#be7c76</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="485" y="305" width="155" height="30" fill="#664e48" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#664e48</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
   </g>
   <g transform="translate(0,10580)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Furina</text>
@@ -3495,30 +3251,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#acac84" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#acac84</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5b8bd8" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#5b8bd8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8bd8</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5b7caa" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b7caa</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#5d5e79" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d5e79</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8b8997" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b8997</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b96541" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b96541</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#acac84" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#acac84</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8bd8</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="175" y="305" width="155" height="30" fill="#5b7caa" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b7caa</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b96541" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b96541</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.49</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c59984" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c59984</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.97</text>
   </g>
   <g transform="translate(0,10932)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gaming</text>
@@ -3609,30 +3357,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#5d5a5f" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5d5a5f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#dc7823" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#cc4c2c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#dc7823</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8d5a3b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d5a3b</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9baa51" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9baa51</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#63704f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#63704f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9c9097" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9097</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.23</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5d5a5f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d5a5f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc4c2c</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
+    <rect x="175" y="305" width="155" height="30" fill="#8d5a3b" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d5a3b</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.88</text>
+    <rect x="330" y="305" width="155" height="30" fill="#9baa51" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9baa51</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
+    <rect x="485" y="305" width="155" height="30" fill="#63704f" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#63704f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
   </g>
   <g transform="translate(0,11284)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ganyu</text>
@@ -3724,30 +3464,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#b4ac9c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#b4ac9c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#234ac1" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6981c7" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#234ac1</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#475499" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6981c7</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.44</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#98bbe7" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#475499</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#98bbe7</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c43c42" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c43c42</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9a6d60" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9a6d60</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c49e61" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c49e61</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b4ac9c" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4ac9c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
   </g>
   <g transform="translate(0,11636)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gorou</text>
@@ -3837,30 +3577,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#434e4c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#434e4c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#903127" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#bc6c56" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#903127</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a38059" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a38059</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.03</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#589ba7" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#589ba7</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#677a7e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#677a7e</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#434e4c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#434e4c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.22</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#abafa6" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#abafa6</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc6c56</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
+    <rect x="330" y="305" width="310" height="30" fill="#a38059" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a38059</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.33</text>
   </g>
   <g transform="translate(0,11988)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">HuTao</text>
@@ -3950,30 +3674,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#8e7ca5" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#8e7ca5</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d04632" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#d04632" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d04632</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#926661" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926661</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ddb28f" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ddb28f</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a99e8d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e8d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8e7ca5" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e7ca5</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.00</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6e5969" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6e5969</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d04632</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
+    <rect x="330" y="305" width="310" height="30" fill="#926661" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926661</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
   </g>
   <g transform="translate(0,12340)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ifa</text>
@@ -4064,30 +3772,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#384148" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#384148</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c07030" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c07030" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07030</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#836556" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#836556</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#47b8ad" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#47b8ad</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#457475" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#457475</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#435566" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#435566</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.97</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7f909e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f909e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07030</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.88</text>
+    <rect x="175" y="305" width="155" height="30" fill="#d4a794" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4a794</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.46</text>
+    <rect x="330" y="305" width="155" height="30" fill="#47b8ad" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#47b8ad</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="485" y="305" width="155" height="30" fill="#457475" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#457475</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
   </g>
   <g transform="translate(0,12692)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jean</text>
@@ -4180,27 +3880,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#356fa1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#356fa1</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5587a6" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.88</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7a98b5" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5587a6</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a98b5</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bf9653" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf9653</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.19</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#96846a" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#96846a</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#864a1e" rx="3"/>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.53</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bf7c5c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#864a1e</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bf7c5c" rx="3"/>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf7c5c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.43</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c69c84" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf7c5c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c69c84</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
   </g>
   <g transform="translate(0,13044)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kachina</text>
@@ -4291,26 +3991,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#a29cb4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#a29cb4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#c47b2c" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c47b2c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47b2c</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="144" y="305" width="124" height="30" fill="#ae8b67" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae8b67</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="268" y="305" width="124" height="30" fill="#248ba7" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#248ba7</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="392" y="305" width="124" height="30" fill="#437567" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437567</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="516" y="305" width="124" height="30" fill="#a29cb4" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#a29cb4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.17</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47b2c</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.91</text>
+    <rect x="175" y="305" width="155" height="30" fill="#ae8b67" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae8b67</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.88</text>
+    <rect x="330" y="305" width="155" height="30" fill="#35cbdb" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#35cbdb</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="485" y="305" width="155" height="30" fill="#437567" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437567</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.17</text>
   </g>
   <g transform="translate(0,13396)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kaeya</text>
@@ -4401,30 +4097,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#39444b" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#39444b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#30567f" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#6d7fbc" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#30567f</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6d7fbc" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d7fbc</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a76453" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a76453</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b48062" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48062</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#58646b" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#58646b</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#39444b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#39444b</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d7fbc</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
+    <rect x="175" y="305" width="155" height="30" fill="#b9c5e2" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b9c5e2</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
+    <rect x="330" y="305" width="155" height="30" fill="#a76453" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a76453</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.92</text>
+    <rect x="485" y="305" width="155" height="30" fill="#736464" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#736464</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.89</text>
   </g>
   <g transform="translate(0,13748)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KamisatoAyaka</text>
@@ -4516,30 +4204,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#b1a45e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#b1a45e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6ca4d8" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#748dbf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca4d8</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4f5f97" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#748dbf</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9ab6d5" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f5f97</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9ab6d5</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.61</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d54d7a" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d54d7a</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.50</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#936f6f" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#936f6f</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.48</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c69f5d" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c69f5d</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.02</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b1a45e" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1a45e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
   </g>
   <g transform="translate(0,14100)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KamisatoAyato</text>
@@ -4631,30 +4319,22 @@
     <rect x="430" y="257" width="70" height="28" fill="#30547c" rx="2"/>
     <text x="465" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#30547c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5346ac" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#5346ac" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5346ac</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#887a94" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#887a94</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#846c4b" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#846c4b</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b69e77" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69e77</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3075c2" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3075c2</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6185b2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6185b2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5346ac</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.24</text>
+    <rect x="175" y="305" width="155" height="30" fill="#887a94" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#887a94</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.82</text>
+    <rect x="330" y="305" width="155" height="30" fill="#6185b2" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6185b2</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.95</text>
+    <rect x="485" y="305" width="155" height="30" fill="#8fb1cf" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8fb1cf</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.76</text>
   </g>
   <g transform="translate(0,14452)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kaveh</text>
@@ -4746,30 +4426,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#26364a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#26364a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c32119" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c32119" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c32119</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#99644e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#99644e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#59796c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#59796c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#92aba4" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#92aba4</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2e577f" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e577f</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6d83a1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d83a1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c32119</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.24</text>
+    <rect x="175" y="305" width="155" height="30" fill="#99644e" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#99644e</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
+    <rect x="330" y="305" width="155" height="30" fill="#2e577f" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e577f</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.99</text>
+    <rect x="485" y="305" width="155" height="30" fill="#6d83a1" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d83a1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.29</text>
   </g>
   <g transform="translate(0,14804)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kazuha</text>
@@ -4861,30 +4533,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#414c3f" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#414c3f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c23723" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#c23723" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23723</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c08161" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08161</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#90cfc3" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#90cfc3</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#869394" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#869394</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#587260" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#587260</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#414c3f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#414c3f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23723</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.16</text>
+    <rect x="330" y="305" width="310" height="30" fill="#c08161" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08161</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
   </g>
   <g transform="translate(0,15156)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Keqing</text>
@@ -4975,30 +4631,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#bab08c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bab08c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3a38c2" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#8989d1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a38c2</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#71689e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71689e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd6395" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd6395</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9e899c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e899c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c69d71" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c69d71</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#785449" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#785449</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8989d1</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
+    <rect x="175" y="305" width="155" height="30" fill="#71689e" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71689e</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
+    <rect x="330" y="305" width="155" height="30" fill="#cd6395" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd6395</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
+    <rect x="485" y="305" width="155" height="30" fill="#9e899c" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e899c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
   </g>
   <g transform="translate(0,15508)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kinich</text>
@@ -5092,27 +4740,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c39f33" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c39f33</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a0815d" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a0815d</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#275b63" rx="3"/>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#74bea0" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#275b63</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#74bea0" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#74bea0</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.75</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#437f7e" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#74bea0</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437f7e</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.10</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3e5dac" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3e5dac</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.05</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2e6178" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e6178</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.72</text>
   </g>
   <g transform="translate(0,15860)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kirara</text>
@@ -5205,27 +4853,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9c753d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c753d</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bb996c" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a58a82" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb996c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#1c8ba9" rx="3"/>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a58a82</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.91</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#2babb7" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#1c8ba9</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#2babb7" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#2babb7</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#1c8ba9" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#2babb7</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#1c8ba9</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.73</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#347646" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#347646</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.69</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7d7e79" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d7e79</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.16</text>
   </g>
   <g transform="translate(0,16212)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Klee</text>
@@ -5316,30 +4964,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#5c4454" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5c4454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b0301a" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#dc4122" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0301a</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b3856c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3856c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#f4e0ca" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f4e0ca</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.08</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#54544b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#54544b</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5c4454" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c4454</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.08</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#908387" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#908387</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#dc4122</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b58e86" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58e86</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.96</text>
   </g>
   <g transform="translate(0,16564)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KujouSara</text>
@@ -5430,30 +5062,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#c7c4c5" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c7c4c5</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cba759" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#cba759" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba759</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#926f35" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926f35</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#64389c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#64389c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#748cbc" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#748cbc</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#63383f" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#63383f</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.88</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8d6862" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d6862</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba759</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.31</text>
+    <rect x="175" y="305" width="155" height="30" fill="#c5ac91" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c5ac91</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.24</text>
+    <rect x="330" y="305" width="155" height="30" fill="#64389c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#64389c</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.13</text>
+    <rect x="485" y="305" width="155" height="30" fill="#888695" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#888695</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.93</text>
   </g>
   <g transform="translate(0,16916)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KukiShinobu</text>
@@ -5543,30 +5167,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#bc683f" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bc683f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bb4d77" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#bb4d77" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bb4d77</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#905668" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#905668</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9db37e" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9db37e</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#5c7553" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c7553</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc683f" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc683f</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b89475" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89475</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bb4d77</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
+    <rect x="175" y="305" width="155" height="30" fill="#c38097" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c38097</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.16</text>
+    <rect x="330" y="305" width="155" height="30" fill="#bc683f" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc683f</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
+    <rect x="485" y="305" width="155" height="30" fill="#b89475" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89475</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.46</text>
   </g>
   <g transform="translate(0,17268)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lansan</text>
@@ -5658,30 +5274,18 @@
     <rect x="220" y="257" width="70" height="28" fill="#382ca8" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#382ca8</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c17329" rx="3"/>
+    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#c17329" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c17329</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a97454" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a97454</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#685b5f" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#685b5f</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.17</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bbacb5" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bbacb5</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#382ca8" rx="3"/>
+    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c17329</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
+    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#a78f86" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78f86</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.42</text>
+    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#866ee2" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#382ca8</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3b2b6f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b2b6f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
+    <text x="536.6666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#866ee2</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.34</text>
   </g>
   <g transform="translate(0,17620)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lanyan</text>
@@ -5773,30 +5377,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#c2b0bd" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#c2b0bd</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#36ccd6" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#339ba4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#36ccd6</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#517677" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#517677</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#143c7c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#143c7c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7192a7" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#7192a7</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7a2b2f" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a2b2f</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bca068" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bca068</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#339ba4</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <rect x="175" y="305" width="155" height="30" fill="#517677" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#517677</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
+    <rect x="330" y="305" width="155" height="30" fill="#bca068" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bca068</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.81</text>
+    <rect x="485" y="305" width="155" height="30" fill="#d1b2a5" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1b2a5</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
   </g>
   <g transform="translate(0,17972)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Layla</text>
@@ -5887,26 +5483,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#241c25" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#241c25</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#334884" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#435c9f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#334884</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
-    <rect x="144" y="305" width="124" height="30" fill="#5f84af" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#5f84af</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="268" y="305" width="124" height="30" fill="#ae4e1c" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae4e1c</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="392" y="305" width="124" height="30" fill="#b08a6a" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08a6a</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="516" y="305" width="124" height="30" fill="#241c25" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#241c25</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.32</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#435c9f</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.31</text>
+    <rect x="175" y="305" width="155" height="30" fill="#7197c4" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7197c4</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.58</text>
+    <rect x="330" y="305" width="155" height="30" fill="#ae4e1c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae4e1c</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.43</text>
+    <rect x="485" y="305" width="155" height="30" fill="#8b786b" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b786b</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.92</text>
   </g>
   <g transform="translate(0,18324)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lynette</text>
@@ -5997,26 +5589,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#868a85" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#868a85</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#34a5bd" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#34a5bd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a5bd</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="144" y="305" width="124" height="30" fill="#41686c" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#41686c</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
-    <rect x="268" y="305" width="124" height="30" fill="#ac6c34" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c34</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
-    <rect x="392" y="305" width="124" height="30" fill="#b08856" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08856</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="516" y="305" width="124" height="30" fill="#868a85" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#868a85</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.26</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a5bd</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
+    <rect x="175" y="305" width="155" height="30" fill="#41686c" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#41686c</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="330" y="305" width="155" height="30" fill="#ac6c34" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c34</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.26</text>
+    <rect x="485" y="305" width="155" height="30" fill="#82716a" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#82716a</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.23</text>
   </g>
   <g transform="translate(0,18676)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lyney</text>
@@ -6107,30 +5695,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#8277a2" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8277a2</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#af7159" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#af7159" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#af7159</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b69382" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69382</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#841536" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#841536</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b54672" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54672</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5d4368" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d4368</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8277a2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8277a2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#af7159</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.06</text>
+    <rect x="175" y="305" width="155" height="30" fill="#886e68" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#886e68</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.39</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b54672" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54672</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
+    <rect x="485" y="305" width="155" height="30" fill="#841536" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#841536</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.00</text>
   </g>
   <g transform="translate(0,19028)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mavuika</text>
@@ -6219,26 +5799,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#241c24" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#241c24</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#bc4b2a" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c85a2f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc4b2a</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="144" y="305" width="124" height="30" fill="#c85a2f" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#c85a2f</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="268" y="305" width="124" height="30" fill="#be7824" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#be7824</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="392" y="305" width="124" height="30" fill="#b09784" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b09784</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="516" y="305" width="124" height="30" fill="#241c24" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#241c24</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.33</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c85a2f</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="175" y="305" width="155" height="30" fill="#bc4b2a" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc4b2a</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.92</text>
+    <rect x="330" y="305" width="155" height="30" fill="#acac04" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#acac04</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.92</text>
+    <rect x="485" y="305" width="155" height="30" fill="#b09784" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b09784</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
   </g>
   <g transform="translate(0,19380)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mika</text>
@@ -6330,30 +5906,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#494c47" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#494c47</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6b84b7" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#6b84b7" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b84b7</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#617083" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#617083</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac6c14" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c14</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#be9f4d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#be9f4d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#494c47" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#494c47</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.30</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dce2e1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dce2e1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.01</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b84b7</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
+    <rect x="175" y="305" width="155" height="30" fill="#b2a1c0" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b2a1c0</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="330" y="305" width="155" height="30" fill="#ac6c14" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c14</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
+    <rect x="485" y="305" width="155" height="30" fill="#887b6d" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#887b6d</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
   </g>
   <g transform="translate(0,19732)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mona</text>
@@ -6445,30 +6013,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#756f6a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#756f6a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7475bd" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7475bd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7475bd</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5b4b88" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5b4b88</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b54450" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54450</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9c5052" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c5052</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#be8f7b" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8f7b</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#756f6a" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#756f6a</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7475bd</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.33</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a1a0ab" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a1a0ab</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b54450" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54450</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
+    <rect x="485" y="305" width="155" height="30" fill="#9c5052" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c5052</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
   </g>
   <g transform="translate(0,20084)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mualani</text>
@@ -6563,27 +6123,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2f5eca" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2f5eca</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#808fc2" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#808fc2</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.43</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b94639" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b94639</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c67ead" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67ead</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#eab432" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#eab432</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.35</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a4a48c" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a48c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.53</text>
   </g>
   <g transform="translate(0,20436)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Nahida</text>
@@ -6673,30 +6233,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#8c90a4" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#8c90a4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#777c41" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#777c41" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#777c41</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#aa9c72" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#aa9c72</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#549468" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#549468</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#547f6c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#547f6c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8c90a4" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c90a4</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.14</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#97929b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#97929b</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#777c41</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.94</text>
+    <rect x="175" y="305" width="155" height="30" fill="#aa9c72" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#aa9c72</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <rect x="330" y="305" width="155" height="30" fill="#549468" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#549468</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.18</text>
+    <rect x="485" y="305" width="155" height="30" fill="#7a9a7c" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a9a7c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.73</text>
   </g>
   <g transform="translate(0,20788)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Navia</text>
@@ -6787,30 +6339,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#51647e" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#51647e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9b6726" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#be8641" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9b6726</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a4855e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4855e</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#3b3533" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b3533</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.30</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#120c0c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#120c0c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.14</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2d66d2" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d66d2</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#51647e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#51647e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8641</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.79</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a4855e" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4855e</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
+    <rect x="330" y="305" width="155" height="30" fill="#2d66d2" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d66d2</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.11</text>
+    <rect x="485" y="305" width="155" height="30" fill="#434e6e" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#434e6e</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.44</text>
   </g>
   <g transform="translate(0,21140)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Neuvillette</text>
@@ -6905,27 +6449,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3078c4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3078c4</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.72</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#3a5b8c" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a5b8c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.48</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9c541c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c541c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a1794b" rx="3"/>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.98</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c1bcbb" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a1794b</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c1bcbb</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#48b9d6" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#48b9d6</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c9d9c" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9d9c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
   </g>
   <g transform="translate(0,21492)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Nilou</text>
@@ -7015,30 +6559,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#8a4454" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8a4454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#348dbb" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#348dbb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#348dbb</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#658aa2" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#658aa2</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c79b70" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c79b70</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#73563a" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#73563a</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#972b1d" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#972b1d</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8a4454" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a4454</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#348dbb</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.40</text>
+    <rect x="175" y="305" width="155" height="30" fill="#658aa2" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#658aa2</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.21</text>
+    <rect x="330" y="305" width="155" height="30" fill="#c75f3f" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75f3f</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c4715d" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c4715d</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
   </g>
   <g transform="translate(0,21844)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ningguang</text>
@@ -7128,30 +6664,6 @@
     <rect x="150" y="257" width="70" height="28" fill="#474454" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#474454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5f3e2a" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5f3e2a</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b08f74" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08f74</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#835f35" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#835f35</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#cabaa8" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#cabaa8</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#474454" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#474454</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.16</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c4c4f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c4c4f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
   </g>
   <g transform="translate(0,22196)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Noelle</text>
@@ -7242,30 +6754,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#d44c7c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#d44c7c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2c3c54" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c3c54</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#847f92" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#847f92</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#735747" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#735747</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#987862" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#987862</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d02c64" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d02c64</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d44c7c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d44c7c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
+    <rect x="20" y="305" width="310" height="30" fill="#d02c64" rx="3"/>
+    <text x="24" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d02c64</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="330" y="305" width="310" height="30" fill="#89264b" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#89264b</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
   </g>
   <g transform="translate(0,22548)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ororon</text>
@@ -7357,30 +6853,26 @@
     <rect x="150" y="257" width="70" height="28" fill="#2c9ca4" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#2c9ca4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3b68d1" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#3b68d1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b68d1</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#435889" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#435889</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d9bb57" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9bb57</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e7e1dd" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e7e1dd</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.02</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2c9ca4" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#2c9ca4</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#57bcf2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#57bcf2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
+    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b68d1</text>
+    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.01</text>
+    <rect x="144" y="305" width="124" height="30" fill="#a999a0" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#a999a0</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.44</text>
+    <rect x="268" y="305" width="124" height="30" fill="#d9bb57" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9bb57</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.98</text>
+    <rect x="392" y="305" width="124" height="30" fill="#57bcf2" rx="3"/>
+    <text x="396" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#57bcf2</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.18</text>
+    <rect x="516" y="305" width="124" height="30" fill="#2c9ca4" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#2c9ca4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
   </g>
   <g transform="translate(0,22900)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Qiqi</text>
@@ -7472,30 +6964,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#e8d691" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e8d691</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3b54b5" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7879b9" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b54b5</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#554f88" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#554f88</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#742f65" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#742f65</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b56a95" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b56a95</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e8d691" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8d691</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#73644e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#73644e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7879b9</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
+    <rect x="175" y="305" width="155" height="30" fill="#9babe1" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9babe1</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b56a95" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b56a95</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.73</text>
+    <rect x="485" y="305" width="155" height="30" fill="#886182" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#886182</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.93</text>
   </g>
   <g transform="translate(0,23252)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">RaidenShogun</text>
@@ -7586,30 +7070,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#b89269" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#b89269</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4e3d82" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#957aca" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e3d82</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6451a1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6451a1</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc2462" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc2462</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#917790" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#917790</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b89269" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89269</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c8a592" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c8a592</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#957aca</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="175" y="305" width="155" height="30" fill="#aba4c8" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#aba4c8</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <rect x="330" y="305" width="155" height="30" fill="#bc2462" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc2462</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
+    <rect x="485" y="305" width="155" height="30" fill="#917790" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#917790</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.05</text>
   </g>
   <g transform="translate(0,23604)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Razor</text>
@@ -7700,30 +7176,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#e0384c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e0384c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d8b66e" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#b3b45c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8b66e</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9d8763" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8763</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6b6d81" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6b6d81</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9ba4b7" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9ba4b7</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e0384c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0384c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#584741" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584741</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3b45c</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.09</text>
+    <rect x="175" y="305" width="155" height="30" fill="#9d8763" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8763</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.47</text>
+    <rect x="330" y="305" width="155" height="30" fill="#e0384c" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0384c</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
+    <rect x="485" y="305" width="155" height="30" fill="#584741" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584741</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.36</text>
   </g>
   <g transform="translate(0,23956)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Rosaria</text>
@@ -7814,30 +7282,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#a08c9c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a08c9c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c22c41" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c22c41" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c22c41</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#987677" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#987677</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c07451" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07451</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8d705d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8d705d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a08c9c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a08c9c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.16</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#1c1118" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c1118</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.05</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c22c41</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
+    <rect x="175" y="305" width="155" height="30" fill="#987677" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#987677</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
+    <rect x="330" y="305" width="155" height="30" fill="#c07451" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07451</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.53</text>
+    <rect x="485" y="305" width="155" height="30" fill="#d1beb6" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1beb6</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
   </g>
   <g transform="translate(0,24308)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">SangonomiyaKokomi</text>
@@ -7929,30 +7389,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#257da4" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#257da4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#33367c" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7377bb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#33367c</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7377bb" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7377bb</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.65</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#cbcaea" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7377bb</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#cbcaea</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ad6958" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ad6958</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.11</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d7a08e" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7a08e</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.17</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#1179e0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#1179e0</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#257da4" rx="3"/>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.03</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#11ccf7" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#257da4</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#11ccf7</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
   </g>
   <g transform="translate(0,24660)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sayu</text>
@@ -8043,30 +7503,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#444474" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#444474</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b29562" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7ca462" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b29562</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7ca462" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ca462</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.40</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a39880" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ca462</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.06</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a39880</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.91</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c5938" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c5938</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#986b57" rx="3"/>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.62</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#655958" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#986b57</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#655958</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#354a7c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#354a7c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.92</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#444474" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#444474</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
   </g>
   <g transform="translate(0,25012)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sethos</text>
@@ -8161,27 +7621,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c17b2a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c17b2a</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#976b67" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.16</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a18c83" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#976b67</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a18c83</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.98</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#3844c4" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3844c4</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#563da9" rx="3"/>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#705a65" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#563da9</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#705a65</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2e9a41" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#2e9a41</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.14</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#298c31" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#298c31</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
   </g>
   <g transform="translate(0,25364)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Shenhe</text>
@@ -8271,30 +7731,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#a4a484" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a4a484</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#86b8ca" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b8ca</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7393ab" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7393ab</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d23e35" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d23e35</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b89074" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#d23e35" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d23e35</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.51</text>
+    <rect x="330" y="305" width="310" height="30" fill="#826c66" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89074</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a4a484" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a484</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d3d5d2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d3d5d2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826c66</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.25</text>
   </g>
   <g transform="translate(0,25716)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">ShikanoinHeizou</text>
@@ -8386,30 +7830,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#158480" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#158480</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c74c29" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#b17135" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c74c29</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b4864b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4864b</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4f1c2a" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f1c2a</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9d94a4" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d94a4</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#158480" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#158480</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a9aea8" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a9aea8</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b17135</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
+    <rect x="175" y="305" width="155" height="30" fill="#957e79" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#957e79</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.03</text>
+    <rect x="330" y="305" width="155" height="30" fill="#158480" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#158480</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.81</text>
+    <rect x="485" y="305" width="155" height="30" fill="#a9aea8" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a9aea8</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.98</text>
   </g>
   <g transform="translate(0,26068)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sigewinne</text>
@@ -8499,30 +7935,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#e8ceb8" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e8ceb8</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7153d0" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7153d0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7153d0</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#406697" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#406697</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ad495d" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ad495d</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d97f8d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d97f8d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9f7558" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f7558</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d2af91" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d2af91</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7153d0</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.11</text>
+    <rect x="175" y="305" width="155" height="30" fill="#7ea9c4" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ea9c4</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="330" y="305" width="155" height="30" fill="#d97f8d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d97f8d</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
+    <rect x="485" y="305" width="155" height="30" fill="#e5abbf" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e5abbf</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
   </g>
   <g transform="translate(0,26420)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Skirk</text>
@@ -8614,30 +8042,18 @@
     <rect x="150" y="257" width="70" height="28" fill="#32b2f1" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#32b2f1</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2c3fd9" rx="3"/>
+    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#5e7dd7" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c3fd9</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5246ba" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5246ba</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#88715d" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#88715d</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.95</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#ad9996" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#ad9996</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#32b2f1" rx="3"/>
+    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e7dd7</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
+    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#9899bb" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#9899bb</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
+    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#32b2f1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#32b2f1</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c3e4fa" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3e4fa</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.34</text>
+    <text x="536.6666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#32b2f1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.72</text>
   </g>
   <g transform="translate(0,26772)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sucrose</text>
@@ -8728,30 +8144,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#34a4ac" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#34a4ac</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d4947c" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#d4947c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4947c</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#978066" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4e6980" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e6980</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.88</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9097a0" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9097a0</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#34a4ac" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a4ac</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3c9494" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#3c9494</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4947c</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.84</text>
+    <rect x="175" y="305" width="155" height="30" fill="#978066" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
+    <rect x="330" y="305" width="155" height="30" fill="#34a4ac" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a4ac</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="485" y="305" width="155" height="30" fill="#9abfb4" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9abfb4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.69</text>
   </g>
   <g transform="translate(0,27124)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Tartaglia</text>
@@ -8843,30 +8251,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#b4aca4" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#b4aca4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#44ace6" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#608fbc" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#44ace6</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#608fbc" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#608fbc</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.56</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#76727b" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#608fbc</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#76727b</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc3c2d" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc3c2d</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.85</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9c6c69" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c6c69</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.88</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#cd8443" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8443</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.98</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b4aca4" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4aca4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
   </g>
   <g transform="translate(0,27476)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Thoma</text>
@@ -8960,27 +8368,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba363e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba363e</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#945043" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bc7354" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#945043</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc7354</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.98</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c3732d" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3732d</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.87</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a4a08a" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a08a</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.58</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9172b0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9172b0</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#585560" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#585560</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.58</text>
   </g>
   <g transform="translate(0,27828)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Tighnari</text>
@@ -9071,30 +8479,30 @@
     <rect x="360" y="257" width="70" height="28" fill="#1b092e" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#1b092e</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c29e30" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#65b673" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29e30</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#65b673" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#65b673</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c1bc82" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#65b673</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c1bc82</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#29c0d3" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#29c0d3</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6c66ac" rx="3"/>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.26</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#51637f" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c66ac</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#51637f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ab3c5c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ab3c5c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.54</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7d563e" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d563e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.69</text>
   </g>
   <g transform="translate(0,28180)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Varesa</text>
@@ -9185,30 +8593,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#599195" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#599195</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#a64743" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c86e67" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a64743</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c86e67" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c86e67</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b59764" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b59764</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7e6340" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6340</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#51c7b4" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#51c7b4</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#599195" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#599195</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c86e67</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.94</text>
+    <rect x="175" y="305" width="155" height="30" fill="#baa99e" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#baa99e</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.33</text>
+    <rect x="330" y="305" width="155" height="30" fill="#51c7b4" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#51c7b4</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.46</text>
+    <rect x="485" y="305" width="155" height="30" fill="#8baa98" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8baa98</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.60</text>
   </g>
   <g transform="translate(0,28532)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Venti</text>
@@ -9299,30 +8699,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#44477c" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#44477c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#806e38" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#806e38</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#968664" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#968664</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#33a18c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#33a18c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#627e85" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#627e85</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#1075a9" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1075a9</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#44477c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#44477c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <rect x="20" y="305" width="155" height="30" fill="#33a18c" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#33a18c</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
+    <rect x="175" y="305" width="155" height="30" fill="#8ba0a6" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8ba0a6</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
+    <rect x="330" y="305" width="155" height="30" fill="#1075a9" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1075a9</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
+    <rect x="485" y="305" width="155" height="30" fill="#7a8289" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7a8289</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.33</text>
   </g>
   <g transform="translate(0,28884)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Wanderer</text>
@@ -9413,30 +8805,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#ae6149" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ae6149</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3caca4" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#588dbd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3caca4</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#588dbd" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#588dbd</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.61</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#41749c" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#588dbd</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#41749c</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.26</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b38253" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b38253</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.29</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#866d57" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#866d57</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.57</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ae6149" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae6149</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#564949" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#564949</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
   </g>
   <g transform="translate(0,29236)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Wriothesley</text>
@@ -9527,26 +8919,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#595c5b" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#595c5b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#393b4f" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#393b4f</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.10</text>
-    <rect x="144" y="305" width="124" height="30" fill="#746c7e" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#746c7e</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="268" y="305" width="124" height="30" fill="#b52438" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52438</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="392" y="305" width="124" height="30" fill="#a96d58" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#a96d58</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.03</text>
-    <rect x="516" y="305" width="124" height="30" fill="#595c5b" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#595c5b</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.27</text>
+    <rect x="20" y="305" width="310" height="30" fill="#b52438" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52438</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.84</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b48375" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48375</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.64</text>
   </g>
   <g transform="translate(0,29588)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xiangling</text>
@@ -9638,30 +9018,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#4c9464" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#4c9464</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c68733" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c64c74" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c68733</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c36050" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c64c74</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.03</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#cf9f78" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c36050</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#cf9f78</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#46699e" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#46699e</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.62</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#394b73" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#394b73</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4c9464" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9464</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.32</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#38663f" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#38663f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
   </g>
   <g transform="translate(0,29940)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xianyun</text>
@@ -9751,30 +9131,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#070b0f" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#070b0f</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c75531" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c75531" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75531</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#856c59" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#856c59</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7ac1b0" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ac1b0</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6ca46c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca46c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#458da1" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#458da1</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3d556d" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d556d</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75531</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.97</text>
+    <rect x="175" y="305" width="155" height="30" fill="#856c59" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#856c59</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
+    <rect x="330" y="305" width="155" height="30" fill="#6ca46c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca46c</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.42</text>
+    <rect x="485" y="305" width="155" height="30" fill="#7ac1b0" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ac1b0</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
   </g>
   <g transform="translate(0,30292)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xiao</text>
@@ -9868,27 +9240,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b04663" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b04663</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#605c8c" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8b787f" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#605c8c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b787f</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.86</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6ecba5" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ecba5</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#518b8c" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#518b8c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.37</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b98740" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b98740</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.56</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b5907a" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5907a</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
   </g>
   <g transform="translate(0,30644)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xilonen</text>
@@ -9983,23 +9355,23 @@
     <rect x="20" y="305" width="124" height="30" fill="#e2831c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2831c</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="144" y="305" width="124" height="30" fill="#9b794a" rx="3"/>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.18</text>
+    <rect x="144" y="305" width="124" height="30" fill="#cd9762" rx="3"/>
     <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b794a</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd9762</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.36</text>
     <rect x="268" y="305" width="124" height="30" fill="#22b6a7" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#22b6a7</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="392" y="305" width="124" height="30" fill="#3b868d" rx="3"/>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.74</text>
+    <rect x="392" y="305" width="124" height="30" fill="#276a62" rx="3"/>
     <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#3b868d</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#276a62</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.55</text>
     <rect x="516" y="305" width="124" height="30" fill="#543c84" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#543c84</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.36</text>
   </g>
   <g transform="translate(0,30996)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xingqiu</text>
@@ -10091,30 +9463,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#7f96b7" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#7f96b7</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c25e13" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#c25e13" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c25e13</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#978066" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#42657c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#42657c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#597b8d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#597b8d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7f96b7" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f96b7</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#1c2028" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c2028</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.97</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c25e13</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.91</text>
+    <rect x="330" y="305" width="310" height="30" fill="#978066" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.02</text>
   </g>
   <g transform="translate(0,31348)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xinyan</text>
@@ -10206,30 +9562,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#3c3444" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3c3444</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b93f2e" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#df5b38" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b93f2e</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#907361" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#907361</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#fcc841" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#fcc841</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3c3c36" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c3c36</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3c3444" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c3444</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.18</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3b2e34" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b2e34</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#df5b38</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="330" y="305" width="310" height="30" fill="#c2a088" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a088</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
   </g>
   <g transform="translate(0,31700)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">YaeMiko</text>
@@ -10321,26 +9661,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#b4c4c4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#b4c4c4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#951b26" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#e3524d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#951b26</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="144" y="305" width="124" height="30" fill="#b64e70" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b64e70</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="268" y="305" width="124" height="30" fill="#534ba1" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#534ba1</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="392" y="305" width="124" height="30" fill="#5c6494" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6494</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
-    <rect x="516" y="305" width="124" height="30" fill="#b4c4c4" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4c4c4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.30</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3524d</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="175" y="305" width="155" height="30" fill="#d9a095" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9a095</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
+    <rect x="330" y="305" width="155" height="30" fill="#534ba1" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#534ba1</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.93</text>
+    <rect x="485" y="305" width="155" height="30" fill="#5c6494" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6494</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.65</text>
   </g>
   <g transform="translate(0,32052)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yanfei</text>
@@ -10431,30 +9767,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#44848c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#44848c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d4a886" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4a886</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b58d69" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58d69</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b0425c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0425c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b15e5e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b15e5e</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3da792" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da792</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#44848c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#44848c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
+    <rect x="20" y="305" width="155" height="30" fill="#b0425c" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0425c</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a5939d" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5939d</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.76</text>
+    <rect x="330" y="305" width="155" height="30" fill="#3da792" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da792</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
+    <rect x="485" y="305" width="155" height="30" fill="#307066" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#307066</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.61</text>
   </g>
   <g transform="translate(0,32404)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yaoyao</text>
@@ -10545,30 +9873,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#94a4c4" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#94a4c4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#eb9d1b" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#eb9d1b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#eb9d1b</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9c9551" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9551</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#874f33" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#874f33</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a27243" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a27243</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6c547c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c547c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#61647c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#61647c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#eb9d1b</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.82</text>
+    <rect x="175" y="305" width="155" height="30" fill="#9c9551" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9551</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="330" y="305" width="155" height="30" fill="#a27243" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a27243</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.48</text>
+    <rect x="485" y="305" width="155" height="30" fill="#874f33" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#874f33</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.75</text>
   </g>
   <g transform="translate(0,32756)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yelan</text>
@@ -10658,30 +9978,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#ac6454" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ac6454</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5665be" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#5665be" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5665be</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5c5f91" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c5f91</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac8f95" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8f95</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.11</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#766363" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#766363</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ac6454" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6454</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a98165" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a98165</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.08</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5665be</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.66</text>
+    <rect x="175" y="305" width="155" height="30" fill="#91a4c8" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#91a4c8</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.42</text>
+    <rect x="330" y="305" width="155" height="30" fill="#ac6454" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6454</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.04</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c7ac97" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7ac97</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.28</text>
   </g>
   <g transform="translate(0,33108)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yoimiya</text>
@@ -10773,30 +10085,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#99bcbe" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#99bcbe</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bf4333" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d8674b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bf4333</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b16745" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8674b</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#886a6d" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b16745</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#e4be54" rx="3"/>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#886a6d</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.50</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d19c70" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e4be54</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d19c70" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d19c70</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f3c581" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d19c70</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f3c581</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.97</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#495494" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#495494</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4b7476" rx="3"/>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#99bcbe" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b7476</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#99bcbe</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.25</text>
   </g>
   <g transform="translate(0,33460)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">YumemizukiMizuki</text>
@@ -10888,30 +10200,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#e3bdb2" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#e3bdb2</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7941cf" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7941cf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7941cf</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a96faf" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a96faf</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4484cc" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4484cc</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6a79aa" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#6a79aa</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#62201d" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#62201d</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8f6c55" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f6c55</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7941cf</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a96faf" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a96faf</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="330" y="305" width="155" height="30" fill="#4484cc" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#4484cc</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.65</text>
+    <rect x="485" y="305" width="155" height="30" fill="#9facc8" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9facc8</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.04</text>
   </g>
   <g transform="translate(0,33812)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yunjin</text>
@@ -11002,30 +10306,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#716d66" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#716d66</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#86b3ca" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b3ca</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#616f92" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#616f92</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c43e4e" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c43e4e</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#915f6f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#915f6f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e08d3c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e08d3c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c2a082" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a082</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <rect x="20" y="305" width="155" height="30" fill="#c43e4e" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c43e4e</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="175" y="305" width="155" height="30" fill="#915f6f" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#915f6f</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <rect x="330" y="305" width="155" height="30" fill="#e08d3c" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e08d3c</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c2a082" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a082</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
   </g>
   <g transform="translate(0,34164)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Zhongli</text>
@@ -11115,29 +10411,17 @@
     <rect x="290" y="257" width="70" height="28" fill="#413d57" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#413d57</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#a47538" rx="3"/>
+    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#a47538" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#a47538</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b8a082" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b8a082</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a04210" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a04210</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4e3425" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e3425</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#413d57" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#413d57</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.05</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9294a5" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9294a5</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
+    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a47538</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.17</text>
+    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#b8a082" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#b8a082</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
+    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#a04210" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="536.6666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a04210</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.15</text>
   </g>
 </svg>

--- a/debug/palettes/colorthief/genshin.svg
+++ b/debug/palettes/colorthief/genshin.svg
@@ -87,31 +87,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#171212</text>
     <rect x="220" y="257" width="70" height="28" fill="#ac8b8e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ac8b8e</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#656db5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#656db5</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4c4f84" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c4f84</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b6440c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6440c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c4854b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c4854b</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bb8e6e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb8e6e</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ac8b8e" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8b8e</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#171212" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#171212</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.17</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c736f" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c736f</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
   </g>
   <g transform="translate(0,372)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Alhaitham</text>
@@ -201,31 +201,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#62b9a9</text>
     <rect x="220" y="257" width="70" height="28" fill="#76bb38" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#76bb38</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3586b6" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3586b6</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2b6670" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b6670</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#33595a" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#33595a</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a68c32" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a68c32</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#efe9df" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#efe9df</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9f7454" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f7454</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.05</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#76bb38" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#76bb38</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#62b9a9" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#62b9a9</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
   </g>
   <g transform="translate(0,724)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Amber</text>
@@ -314,31 +314,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#544956</text>
     <rect x="290" y="257" width="70" height="28" fill="#6b616c" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6b616c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d2322a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d2322a</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#d38373" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d38373</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9f4741" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9f4741</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cba783" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba783</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e8d6cb" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8d6cb</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#68554e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#68554e</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#544956" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#544956</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.20</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b1aab3" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1aab3</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.19</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9f919e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f919e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
   </g>
   <g transform="translate(0,1076)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">AratakiItto</text>
@@ -428,31 +428,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#f3ebda</text>
     <rect x="290" y="257" width="70" height="28" fill="#333432" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#333432</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5d476f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d476f</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#3e314c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3e314c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9086a1" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9086a1</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c34225" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c34225</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bc8365" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8365</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#da8c35" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8c35</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e6c8a1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e6c8a1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
   </g>
   <g transform="translate(0,1428)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Arlecchino</text>
@@ -543,23 +543,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#aca074" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#aca074</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#565b65" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#565b65</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.16</text>
-    <rect x="144" y="305" width="124" height="30" fill="#c7cad0" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7cad0</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.14</text>
+    <rect x="144" y="305" width="124" height="30" fill="#8d929d" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#8d929d</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
     <rect x="268" y="305" width="124" height="30" fill="#c01415" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01415</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
-    <rect x="392" y="305" width="124" height="30" fill="#671314" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#671314</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
+    <rect x="392" y="305" width="124" height="30" fill="#894e50" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#894e50</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="516" y="305" width="124" height="30" fill="#aca074" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#aca074</text>
@@ -652,31 +652,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#957944</text>
     <rect x="220" y="257" width="70" height="28" fill="#8e896e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8e896e</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2c7bba" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#2c7bba</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#0d3756" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0d3756</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7d669c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d669c</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#18beae" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#18beae</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#108b85" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#108b85</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#509ca5" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#509ca5</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#957944" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#957944</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#efe1d4" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#efe1d4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8e896e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e896e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
   </g>
   <g transform="translate(0,2132)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Barbara</text>
@@ -767,23 +767,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#746f70" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#746f70</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#3696bf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#3696bf</text>
     <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="144" y="305" width="124" height="30" fill="#0f1a35" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0f1a35</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <rect x="144" y="305" width="124" height="30" fill="#415d8e" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#415d8e</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
     <rect x="268" y="305" width="124" height="30" fill="#cc8e4a" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc8e4a</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="392" y="305" width="124" height="30" fill="#d79d7d" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#d79d7d</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
+    <rect x="392" y="305" width="124" height="30" fill="#bca474" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#bca474</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
     <rect x="516" y="305" width="124" height="30" fill="#746f70" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#746f70</text>
@@ -876,31 +876,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ae6a5b</text>
     <rect x="290" y="257" width="70" height="28" fill="#524c43" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#524c43</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba3549" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba3549</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#25090d" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#25090d</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8e5653" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8e5653</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#83acb6" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#83acb6</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#64516d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#64516d</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9783a5" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9783a5</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ae6a5b" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae6a5b</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e4ccc1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e4ccc1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c19981" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c19981</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
   </g>
   <g transform="translate(0,2836)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Bennett</text>
@@ -990,31 +990,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6d7074</text>
     <rect x="150" y="257" width="70" height="28" fill="#3d4e5b" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3d4e5b</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d6942b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d6942b</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#cf1308" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cf1308</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#947255" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#947255</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#343b63" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#343b63</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#444a77" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#444a77</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3d4e5b" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d4e5b</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.01</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6d7074" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d7074</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.31</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
   </g>
   <g transform="translate(0,3188)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Candace</text>
@@ -1104,31 +1104,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2278ad</text>
     <rect x="220" y="257" width="70" height="28" fill="#32606a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#32606a</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2b3d7a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b3d7a</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4b3c94" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b3c94</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#635780" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#635780</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#805231" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#805231</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dcac8d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dcac8d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b47e53" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47e53</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#1fa2c5" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#1fa2c5</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.02</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2278ad" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2278ad</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#32606a" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#32606a</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
   </g>
   <g transform="translate(0,3540)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Charlotte</text>
@@ -1218,31 +1218,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#3da5af</text>
     <rect x="290" y="257" width="70" height="28" fill="#326399" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#326399</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c54e75" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c54e75</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#701e34" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#701e34</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a4549c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a4549c</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#86704b" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#86704b</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f0d6bf" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f0d6bf</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bfaa81" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bfaa81</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#326399" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#326399</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3da5af" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da5af</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
   </g>
   <g transform="translate(0,3892)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chasca</text>
@@ -1332,23 +1332,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#44334e" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#44334e</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#be483f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#be483f</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="144" y="305" width="124" height="30" fill="#621924" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#621924</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <rect x="144" y="305" width="124" height="30" fill="#a2947c" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2947c</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
     <rect x="268" y="305" width="124" height="30" fill="#3b4479" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b4479</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
-    <rect x="392" y="305" width="124" height="30" fill="#869cb9" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#869cb9</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
+    <rect x="392" y="305" width="124" height="30" fill="#6271a8" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6271a8</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.05</text>
     <rect x="516" y="305" width="124" height="30" fill="#44334e" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#44334e</text>
@@ -1443,31 +1443,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c39955</text>
     <rect x="290" y="257" width="70" height="28" fill="#b39c64" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b39c64</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#432b69" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#432b69</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#311c4e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#311c4e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6a5390" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a5390</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c40f50" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c40f50</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#772b30" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#772b30</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9a665f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9a665f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c39955" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c39955</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dac8b7" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dac8b7</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b39c64" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b39c64</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
   </g>
   <g transform="translate(0,4596)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chiori</text>
@@ -1557,31 +1557,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3c3a4b</text>
     <rect x="290" y="257" width="70" height="28" fill="#9587b1" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#9587b1</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba341e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba341e</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.08</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#36080a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#36080a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#864f40" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#864f40</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd8934" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8934</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f8d160" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f8d160</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c3a38d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3a38d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9587b1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9587b1</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.00</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3c3a4b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c3a4b</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#53576a" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#53576a</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
   </g>
   <g transform="translate(0,4948)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Chongyun</text>
@@ -1672,23 +1672,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#1d1b1d" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#1d1b1d</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#6b9dc3" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b9dc3</text>
     <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="144" y="305" width="124" height="30" fill="#061741" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#061741</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <rect x="144" y="305" width="124" height="30" fill="#618aa9" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#618aa9</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.05</text>
     <rect x="268" y="305" width="124" height="30" fill="#8a6430" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a6430</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="392" y="305" width="124" height="30" fill="#cea05f" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#cea05f</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
+    <rect x="392" y="305" width="124" height="30" fill="#84544c" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#84544c</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="516" y="305" width="124" height="30" fill="#1d1b1d" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1d1b1d</text>
@@ -1783,31 +1783,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#92e6f4</text>
     <rect x="150" y="257" width="70" height="28" fill="#408ca0" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#408ca0</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#423fb6" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#423fb6</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9186e7" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9186e7</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5350aa" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5350aa</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#e3a7c0" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3a7c0</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f4e3e4" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f4e3e4</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#71554c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71554c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#408ca0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#408ca0</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#92e6f4" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#92e6f4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
   </g>
   <g transform="translate(0,5652)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Clorinde</text>
@@ -1898,31 +1898,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#7e6b61</text>
     <rect x="150" y="257" width="70" height="28" fill="#a78356" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a78356</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2031b9" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2031b9</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#85b2e1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#85b2e1</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#575690" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#575690</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a78282" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78282</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#534647" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#534647</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.15</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a78356" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a78356</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7e6b61" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6b61</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.15</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
   </g>
   <g transform="translate(0,6004)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Collei</text>
@@ -2012,31 +2012,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2859a0</text>
     <rect x="150" y="257" width="70" height="28" fill="#8c3484" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8c3484</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#edbd75" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#edbd75</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#f7e193" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#f7e193</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#897f5c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#897f5c</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6cac3c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6cac3c</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3c6c24" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c6c24</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c0cb7d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0cb7d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2859a0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2859a0</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c3484" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c3484</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
   </g>
   <g transform="translate(0,6356)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Cyno</text>
@@ -2127,31 +2127,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#f8e5a8</text>
     <rect x="290" y="257" width="70" height="28" fill="#cda475" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#cda475</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4464ac" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4464ac</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#3b3d7d" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b3d7d</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4c44ac" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c44ac</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9c5f31" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c5f31</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b88772" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b88772</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#966b54" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#966b54</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bb8b59" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb8b59</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#f8e5a8" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f8e5a8</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cda475" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cda475</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
   </g>
   <g transform="translate(0,6708)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Dahlia</text>
@@ -2241,31 +2241,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#495369</text>
     <rect x="290" y="257" width="70" height="28" fill="#444649" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#444649</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#772131" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#772131</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5b232c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5b232c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#985e5a" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#985e5a</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c08e6c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08e6c</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f5e6d8" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f5e6d8</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b1a16c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1a16c</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6e85a1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6e85a1</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#495369" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#495369</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.00</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
   </g>
   <g transform="translate(0,7060)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Dehya</text>
@@ -2356,31 +2356,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6d5a64</text>
     <rect x="290" y="257" width="70" height="28" fill="#a4949c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#a4949c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c71a11" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c71a11</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6d332b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d332b</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#96533d" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#96533d</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#da8b33" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#da8b33</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e1ba8a" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1ba8a</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a99e84" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e84</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6d5a64" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d5a64</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#52434c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#52434c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.11</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a4949c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4949c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
   </g>
   <g transform="translate(0,7412)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Diluc</text>
@@ -2469,31 +2469,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#51535c</text>
     <rect x="290" y="257" width="70" height="28" fill="#8c8c94" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#8c8c94</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cc472d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cc472d</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e9dcd3" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e9dcd3</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a17868" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a17868</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#879596" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#879596</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.19</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#212c2d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#212c2d</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#545c5c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#545c5c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2b333c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b333c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.18</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#111619" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#111619</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8c94" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8c94</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
   </g>
   <g transform="translate(0,7764)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Diona</text>
@@ -2582,31 +2582,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#4c9e89</text>
     <rect x="150" y="257" width="70" height="28" fill="#276f63" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#276f63</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ad7244" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ad7244</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#da9d9b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#da9d9b</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ba776b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ba776b</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4c7fac" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c7fac</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#adbcd5" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#adbcd5</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#54547c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#54547c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#276f63" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#276f63</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c9e89" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9e89</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
   </g>
   <g transform="translate(0,8116)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Dori</text>
@@ -2697,31 +2697,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bdb0b0</text>
     <rect x="360" y="257" width="70" height="28" fill="#d26e87" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#d26e87</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4625a4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4625a4</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#cbb2ee" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#cbb2ee</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8e649b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8e649b</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8f6541" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f6541</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f7efe1" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f7efe1</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c29b79" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29b79</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d26e87" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d26e87</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e8c4bd" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8c4bd</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6e374b" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6e374b</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
   </g>
   <g transform="translate(0,8468)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Emilie</text>
@@ -2810,31 +2810,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#625d70</text>
     <rect x="290" y="257" width="70" height="28" fill="#403c4d" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#403c4d</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c39148" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c39148</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#d5cba4" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d5cba4</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bc6275" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc6275</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#215646" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#215646</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3d7863" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d7863</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#918faf" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#918faf</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.08</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#403c4d" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#403c4d</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#625d70" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#625d70</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
   </g>
   <g transform="translate(0,8820)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Escoffier</text>
@@ -2925,31 +2925,31 @@
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2d7185</text>
     <rect x="430" y="257" width="70" height="28" fill="#2e5376" rx="2"/>
     <text x="465" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2e5376</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d94b8c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d94b8c</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7f2c49" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7f2c49</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bf7476" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf7476</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac7241" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac7241</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dfba8f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dfba8f</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d9a46a" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9a46a</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2085b9" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#2085b9</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2d7185" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d7185</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#788490" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#788490</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
   </g>
   <g transform="translate(0,9172)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Eula</text>
@@ -3039,31 +3039,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#be8a62</text>
     <rect x="290" y="257" width="70" height="28" fill="#b46c44" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b46c44</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#0e3362" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0e3362</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#0f173c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0f173c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5e839c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5e839c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8f89" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8f89</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.26</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d8dfdd" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8dfdd</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.15</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.98</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b46c44" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b46c44</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#be8a62" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8a62</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
   </g>
   <g transform="translate(0,9524)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Faruzan</text>
@@ -3153,31 +3153,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#4798bf</text>
     <rect x="290" y="257" width="70" height="28" fill="#4cacd4" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#4cacd4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6a493a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a493a</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e8cfad" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8cfad</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8a7256" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a7256</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#69909d" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#69909d</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bbd9dc" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bbd9dc</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9cc0c3" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9cc0c3</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4cacd4" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4cacd4</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#102038" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#102038</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4798bf" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4798bf</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
   </g>
   <g transform="translate(0,9876)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Fischl</text>
@@ -3266,31 +3266,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#776d61</text>
     <rect x="290" y="257" width="70" height="28" fill="#bc8f49" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bc8f49</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b574e5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b574e5</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#26122e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#26122e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#614d90" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#614d90</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#724f4f" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#724f4f</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.99</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#ba9092" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#ba9092</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.91</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#966f6b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#966f6b</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc8f49" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc8f49</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e7ccb1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e7ccb1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c0976d" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0976d</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
   </g>
   <g transform="translate(0,10228)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Freminet</text>
@@ -3379,31 +3379,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#cea89a</text>
     <rect x="290" y="257" width="70" height="28" fill="#be7c76" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#be7c76</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f507a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f507a</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.93</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#121427" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#121427</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8096aa" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8096aa</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc9059" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc9059</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f1e2ce" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f1e2ce</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#967965" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#967965</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#be7c76" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#be7c76</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cea89a" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cea89a</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#664e48" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#664e48</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
   </g>
   <g transform="translate(0,10580)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Furina</text>
@@ -3494,31 +3494,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b96541</text>
     <rect x="360" y="257" width="70" height="28" fill="#acac84" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#acac84</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5b8bd8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8bd8</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#86c1e5" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#86c1e5</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5b7caa" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b7caa</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#5d5e79" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d5e79</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#241a22" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#241a22</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8b8997" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b8997</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b96541" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b96541</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d9bc93" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9bc93</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#acac84" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#acac84</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
   </g>
   <g transform="translate(0,10932)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gaming</text>
@@ -3608,31 +3608,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#34343e</text>
     <rect x="220" y="257" width="70" height="28" fill="#5d5a5f" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5d5a5f</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#dc7823" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#dc7823</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#eec96d" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#eec96d</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8d5a3b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d5a3b</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9baa51" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9baa51</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#63704f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#63704f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9c9097" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9097</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.23</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#34343e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#34343e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5d5a5f" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d5a5f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
   </g>
   <g transform="translate(0,11284)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ganyu</text>
@@ -3723,31 +3723,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#c49e61</text>
     <rect x="150" y="257" width="70" height="28" fill="#b4ac9c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#b4ac9c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#234ac1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#234ac1</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#98bbe7" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#98bbe7</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#475499" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#475499</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c43c42" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c43c42</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4e100f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e100f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9a6d60" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9a6d60</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c49e61" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c49e61</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b4ac9c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4ac9c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
   </g>
   <g transform="translate(0,11636)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gorou</text>
@@ -3836,31 +3836,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#abafa6</text>
     <rect x="150" y="257" width="70" height="28" fill="#434e4c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#434e4c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#903127" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#903127</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e2ceb8" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2ceb8</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a38059" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a38059</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.03</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#589ba7" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#589ba7</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4a626f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4a626f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.97</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#677a7e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#677a7e</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#434e4c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#434e4c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.22</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#abafa6" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#abafa6</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.21</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
   </g>
   <g transform="translate(0,11988)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">HuTao</text>
@@ -3949,31 +3949,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6e5969</text>
     <rect x="150" y="257" width="70" height="28" fill="#8e7ca5" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#8e7ca5</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d04632" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d04632</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#da795c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#da795c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#926661" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926661</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ddb28f" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ddb28f</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f5e3d1" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f5e3d1</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a99e8d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a99e8d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8e7ca5" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e7ca5</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.00</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6e5969" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6e5969</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.14</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
   </g>
   <g transform="translate(0,12340)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ifa</text>
@@ -4063,31 +4063,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#435566</text>
     <rect x="290" y="257" width="70" height="28" fill="#384148" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#384148</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c07030" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07030</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#290907" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#290907</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#836556" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#836556</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#47b8ad" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#47b8ad</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#457475" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#457475</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#435566" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#435566</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.97</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#384148" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#384148</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7f909e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f909e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
   </g>
   <g transform="translate(0,12692)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jean</text>
@@ -4176,31 +4176,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#864a1e</text>
     <rect x="290" y="257" width="70" height="28" fill="#bf7c5c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bf7c5c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#356fa1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#356fa1</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2c4f6e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c4f6e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5587a6" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#5587a6</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bf9653" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf9653</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c7a374" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7a374</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#96846a" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#96846a</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#864a1e" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#864a1e</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c69c84" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c69c84</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bf7c5c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf7c5c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
   </g>
   <g transform="translate(0,13044)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kachina</text>
@@ -4290,23 +4290,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#a29cb4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#a29cb4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#c47b2c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47b2c</text>
     <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="144" y="305" width="124" height="30" fill="#ecd47a" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#ecd47a</text>
+    <rect x="144" y="305" width="124" height="30" fill="#ae8b67" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae8b67</text>
     <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="268" y="305" width="124" height="30" fill="#248ba7" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#248ba7</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="392" y="305" width="124" height="30" fill="#275862" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#275862</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
+    <rect x="392" y="305" width="124" height="30" fill="#437567" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#437567</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
     <rect x="516" y="305" width="124" height="30" fill="#a29cb4" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#a29cb4</text>
@@ -4400,31 +4400,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#58646b</text>
     <rect x="150" y="257" width="70" height="28" fill="#39444b" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#39444b</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#30567f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#30567f</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8fa9d6" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8fa9d6</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6d7fbc" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d7fbc</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a76453" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a76453</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d3aa87" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d3aa87</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b48062" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48062</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#58646b" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#58646b</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#39444b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#39444b</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
   </g>
   <g transform="translate(0,13748)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KamisatoAyaka</text>
@@ -4515,31 +4515,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#c69f5d</text>
     <rect x="220" y="257" width="70" height="28" fill="#b1a45e" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#b1a45e</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6ca4d8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca4d8</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9ab6d5" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9ab6d5</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4f5f97" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f5f97</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d54d7a" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d54d7a</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#da9799" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#da9799</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#936f6f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#936f6f</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c69f5d" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c69f5d</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b1a45e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b1a45e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
   </g>
   <g transform="translate(0,14100)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KamisatoAyato</text>
@@ -4630,31 +4630,31 @@
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#31b9ee</text>
     <rect x="430" y="257" width="70" height="28" fill="#30547c" rx="2"/>
     <text x="465" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#30547c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5346ac" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5346ac</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#383d8a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#383d8a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#887a94" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#887a94</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#846c4b" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#846c4b</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d0bfac" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d0bfac</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b69e77" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69e77</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3075c2" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3075c2</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#31b9ee" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#31b9ee</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6185b2" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6185b2</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
   </g>
   <g transform="translate(0,14452)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kaveh</text>
@@ -4745,31 +4745,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2e577f</text>
     <rect x="220" y="257" width="70" height="28" fill="#26364a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#26364a</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c32119" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c32119</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e2cdb1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2cdb1</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#99644e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#99644e</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#59796c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#59796c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#92aba4" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#92aba4</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.10</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2e577f" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e577f</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#26364a" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#26364a</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#6d83a1" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6d83a1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
   </g>
   <g transform="translate(0,14804)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kazuha</text>
@@ -4860,31 +4860,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#587260</text>
     <rect x="150" y="257" width="70" height="28" fill="#414c3f" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#414c3f</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c23723" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23723</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#67291f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#67291f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c08161" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c08161</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#90cfc3" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#90cfc3</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#535c5c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#535c5c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.21</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#869394" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#869394</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#587260" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#587260</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#414c3f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#414c3f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
   </g>
   <g transform="translate(0,15156)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Keqing</text>
@@ -4974,31 +4974,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c69d71</text>
     <rect x="290" y="257" width="70" height="28" fill="#bab08c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bab08c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3a38c2" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a38c2</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8989d1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8989d1</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#71689e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71689e</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd6395" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd6395</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#45323f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#45323f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.01</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9e899c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e899c</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c69d71" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c69d71</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c99987" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c99987</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#785449" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#785449</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
   </g>
   <g transform="translate(0,15508)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kinich</text>
@@ -5088,31 +5088,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2b415b</text>
     <rect x="290" y="257" width="70" height="28" fill="#3e5dac" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3e5dac</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c39f33" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c39f33</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a45c10" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a45c10</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a0815d" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a0815d</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#275b63" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#275b63</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#74bea0" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#74bea0</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3e5dac" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3e5dac</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2e6178" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e6178</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
   </g>
   <g transform="translate(0,15860)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Kirara</text>
@@ -5201,31 +5201,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#b3b6ab</text>
     <rect x="220" y="257" width="70" height="28" fill="#347646" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#347646</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9c753d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c753d</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ebd1b3" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ebd1b3</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bb996c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb996c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#1c8ba9" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#1c8ba9</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#207288" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#207288</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#2babb7" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#2babb7</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#347646" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#347646</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b3b6ab" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3b6ab</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.17</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7d7e79" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d7e79</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
   </g>
   <g transform="translate(0,16212)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Klee</text>
@@ -5315,31 +5315,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#504c5c</text>
     <rect x="290" y="257" width="70" height="28" fill="#5c4454" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5c4454</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b0301a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0301a</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6c2b24" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c2b24</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b3856c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3856c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#f4e0ca" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f4e0ca</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.08</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#54544b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#54544b</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.18</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5c4454" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c4454</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.08</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#504c5c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#504c5c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#908387" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#908387</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
   </g>
   <g transform="translate(0,16564)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KujouSara</text>
@@ -5429,31 +5429,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8d6862</text>
     <rect x="220" y="257" width="70" height="28" fill="#c7c4c5" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c7c4c5</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cba759" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#cba759</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#eecaae" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#eecaae</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#926f35" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926f35</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#64389c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#64389c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3c5c8c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c5c8c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#748cbc" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#748cbc</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#63383f" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#63383f</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.88</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8d6862" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8d6862</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.11</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
   </g>
   <g transform="translate(0,16916)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">KukiShinobu</text>
@@ -5542,31 +5542,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#260709</text>
     <rect x="290" y="257" width="70" height="28" fill="#bc683f" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bc683f</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bb4d77" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bb4d77</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c38097" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c38097</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#905668" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#905668</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9db37e" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9db37e</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#5c7553" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c7553</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc683f" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc683f</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#260709" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#260709</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b89475" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89475</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
   </g>
   <g transform="translate(0,17268)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lansan</text>
@@ -5657,31 +5657,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3b2b6f</text>
     <rect x="220" y="257" width="70" height="28" fill="#382ca8" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#382ca8</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c17329" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c17329</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#446414" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#446414</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a97454" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a97454</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#685b5f" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#685b5f</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.17</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e4d9db" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e4d9db</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bbacb5" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bbacb5</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#382ca8" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#382ca8</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#866ee2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#866ee2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3b2b6f" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b2b6f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
   </g>
   <g transform="translate(0,17620)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lanyan</text>
@@ -5772,31 +5772,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bca068</text>
     <rect x="360" y="257" width="70" height="28" fill="#c2b0bd" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#c2b0bd</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#36ccd6" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#36ccd6</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4deeea" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#4deeea</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#517677" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#517677</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#143c7c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#143c7c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3a596b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a596b</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7192a7" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#7192a7</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7a2b2f" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a2b2f</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d1b2a5" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1b2a5</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bca068" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bca068</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
   </g>
   <g transform="translate(0,17972)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Layla</text>
@@ -5886,23 +5886,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#241c25" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#241c25</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#334884" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#334884</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
-    <rect x="144" y="305" width="124" height="30" fill="#90b8d7" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#90b8d7</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <rect x="144" y="305" width="124" height="30" fill="#5f84af" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#5f84af</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
     <rect x="268" y="305" width="124" height="30" fill="#ae4e1c" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae4e1c</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="392" y="305" width="124" height="30" fill="#b68450" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b68450</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
+    <rect x="392" y="305" width="124" height="30" fill="#b08a6a" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08a6a</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="516" y="305" width="124" height="30" fill="#241c25" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#241c25</text>
@@ -5996,23 +5996,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#868a85" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#868a85</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#34a5bd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a5bd</text>
     <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="144" y="305" width="124" height="30" fill="#14556b" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#14556b</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
+    <rect x="144" y="305" width="124" height="30" fill="#41686c" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#41686c</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
     <rect x="268" y="305" width="124" height="30" fill="#ac6c34" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c34</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
-    <rect x="392" y="305" width="124" height="30" fill="#dfd3ca" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#dfd3ca</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.88</text>
+    <rect x="392" y="305" width="124" height="30" fill="#b08856" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08856</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="516" y="305" width="124" height="30" fill="#868a85" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#868a85</text>
@@ -6106,31 +6106,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5d4368</text>
     <rect x="220" y="257" width="70" height="28" fill="#8277a2" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8277a2</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#af7159" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#af7159</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ecdacc" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ecdacc</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b69382" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b69382</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#841536" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#841536</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4b1b23" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b1b23</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b54672" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54672</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5d4368" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d4368</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#412d4c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#412d4c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8277a2" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8277a2</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
   </g>
   <g transform="translate(0,19028)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mavuika</text>
@@ -6218,23 +6218,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#241c24" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#241c24</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#bc4b2a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc4b2a</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="144" y="305" width="124" height="30" fill="#522016" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#522016</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <rect x="144" y="305" width="124" height="30" fill="#c85a2f" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#c85a2f</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
     <rect x="268" y="305" width="124" height="30" fill="#be7824" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#be7824</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="392" y="305" width="124" height="30" fill="#eaad64" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#eaad64</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <rect x="392" y="305" width="124" height="30" fill="#b09784" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b09784</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="516" y="305" width="124" height="30" fill="#241c24" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#241c24</text>
@@ -6329,31 +6329,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#dce2e1</text>
     <rect x="150" y="257" width="70" height="28" fill="#494c47" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#494c47</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6b84b7" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#6b84b7</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8fbfe1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8fbfe1</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#617083" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#617083</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac6c14" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6c14</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d7c787" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7c787</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#be9f4d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#be9f4d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#494c47" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#494c47</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.30</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dce2e1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dce2e1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.17</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.01</text>
   </g>
   <g transform="translate(0,19732)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mona</text>
@@ -6444,31 +6444,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#be8f7b</text>
     <rect x="220" y="257" width="70" height="28" fill="#756f6a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#756f6a</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7475bd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7475bd</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4a3969" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4a3969</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5b4b88" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5b4b88</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b54450" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b54450</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#411215" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#411215</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9c5052" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c5052</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#be8f7b" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#be8f7b</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#edd7c1" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#edd7c1</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#756f6a" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#756f6a</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
   </g>
   <g transform="translate(0,20084)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mualani</text>
@@ -6559,31 +6559,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#836833</text>
     <rect x="220" y="257" width="70" height="28" fill="#a4a48c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#a4a48c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2f5eca" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2f5eca</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#1c3864" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c3864</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#808fc2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#808fc2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b94639" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b94639</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e9b89a" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e9b89a</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c67ead" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67ead</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#eab432" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#eab432</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#836833" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#836833</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a4a48c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a48c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
   </g>
   <g transform="translate(0,20436)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Nahida</text>
@@ -6672,31 +6672,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#97929b</text>
     <rect x="150" y="257" width="70" height="28" fill="#8c90a4" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#8c90a4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#777c41" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#777c41</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#f9f4ea" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#f9f4ea</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#aa9c72" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#aa9c72</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#549468" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#549468</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c1d1bd" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c1d1bd</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.98</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#547f6c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#547f6c</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8c90a4" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c90a4</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.14</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#97929b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#97929b</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.27</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
   </g>
   <g transform="translate(0,20788)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Navia</text>
@@ -6786,31 +6786,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#39aff9</text>
     <rect x="290" y="257" width="70" height="28" fill="#51647e" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#51647e</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9b6726" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9b6726</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#f7da96" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#f7da96</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a4855e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4855e</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#3b3533" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b3533</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.30</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#120c0c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#120c0c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.14</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2d66d2" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d66d2</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#39aff9" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#39aff9</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#51647e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#51647e</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
   </g>
   <g transform="translate(0,21140)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Neuvillette</text>
@@ -6901,31 +6901,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#48b9d6</text>
     <rect x="150" y="257" width="70" height="28" fill="#4c9d9c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#4c9d9c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3078c4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3078c4</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#1b2c69" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1b2c69</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#3a5b8c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a5b8c</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9c541c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9c541c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a1794b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a1794b</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#48b9d6" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#48b9d6</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c9d9c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9d9c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
   </g>
   <g transform="translate(0,21492)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Nilou</text>
@@ -7014,31 +7014,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#cfa092</text>
     <rect x="360" y="257" width="70" height="28" fill="#8a4454" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8a4454</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#348dbb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#348dbb</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#163e65" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#163e65</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#658aa2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#658aa2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c79b70" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c79b70</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#debd98" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#debd98</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#73563a" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#73563a</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#972b1d" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#972b1d</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cfa092" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cfa092</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8a4454" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a4454</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
   </g>
   <g transform="translate(0,21844)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ningguang</text>
@@ -7127,31 +7127,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#4c4c4f</text>
     <rect x="150" y="257" width="70" height="28" fill="#474454" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#474454</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5f3e2a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5f3e2a</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#312213" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#312213</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b08f74" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08f74</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#835f35" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#835f35</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f3d87d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f3d87d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#cabaa8" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#cabaa8</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#474454" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#474454</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.16</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c4c4f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c4c4f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.25</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
   </g>
   <g transform="translate(0,22196)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Noelle</text>
@@ -7241,31 +7241,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#dc346c</text>
     <rect x="290" y="257" width="70" height="28" fill="#d44c7c" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#d44c7c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2c3c54" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c3c54</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#35445a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#35445a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#847f92" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#847f92</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#735747" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#735747</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f6e9da" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f6e9da</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#987862" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#987862</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d02c64" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d02c64</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#89264b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#89264b</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d44c7c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d44c7c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
   </g>
   <g transform="translate(0,22548)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Ororon</text>
@@ -7356,31 +7356,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#57bcf2</text>
     <rect x="150" y="257" width="70" height="28" fill="#2c9ca4" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#2c9ca4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3b68d1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b68d1</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#1d376a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1d376a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#435889" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#435889</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d9bb57" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9bb57</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e7e1dd" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e7e1dd</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.06</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.02</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2c9ca4" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#2c9ca4</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#57bcf2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#57bcf2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
   </g>
   <g transform="translate(0,22900)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Qiqi</text>
@@ -7471,31 +7471,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#73644e</text>
     <rect x="220" y="257" width="70" height="28" fill="#e8d691" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e8d691</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3b54b5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b54b5</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8cd4f4" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8cd4f4</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#554f88" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#554f88</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#742f65" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#742f65</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d5b2b6" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d5b2b6</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b56a95" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b56a95</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e8d691" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8d691</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#73644e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#73644e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.00</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
   </g>
   <g transform="translate(0,23252)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">RaidenShogun</text>
@@ -7585,31 +7585,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#c8a592</text>
     <rect x="150" y="257" width="70" height="28" fill="#b89269" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#b89269</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4e3d82" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e3d82</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#1a1239" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1a1239</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6451a1" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6451a1</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc2462" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc2462</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b87dcc" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b87dcc</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#917790" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#917790</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b89269" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89269</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c8a592" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c8a592</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
   </g>
   <g transform="translate(0,23604)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Razor</text>
@@ -7699,31 +7699,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#584741</text>
     <rect x="220" y="257" width="70" height="28" fill="#e0384c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e0384c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d8b66e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8b66e</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b3b45c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3b45c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9d8763" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8763</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6b6d81" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6b6d81</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9ba4b7" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9ba4b7</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e0384c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0384c</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#db8941" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#db8941</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#584741" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584741</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
   </g>
   <g transform="translate(0,23956)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Rosaria</text>
@@ -7813,31 +7813,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#1c1118</text>
     <rect x="150" y="257" width="70" height="28" fill="#a08c9c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a08c9c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c22c41" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c22c41</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#791c2f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#791c2f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#987677" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#987677</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c07451" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c07451</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b8966f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b8966f</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8d705d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8d705d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a08c9c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a08c9c</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.16</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#1c1118" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c1118</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.97</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.05</text>
   </g>
   <g transform="translate(0,24308)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">SangonomiyaKokomi</text>
@@ -7928,31 +7928,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e1ecf9</text>
     <rect x="290" y="257" width="70" height="28" fill="#257da4" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#257da4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#33367c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#33367c</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9a9ed6" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9a9ed6</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7377bb" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7377bb</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ad6958" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ad6958</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d7a08e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7a08e</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#1179e0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#1179e0</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#257da4" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#257da4</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
   </g>
   <g transform="translate(0,24660)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sayu</text>
@@ -8042,31 +8042,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#354a7c</text>
     <rect x="220" y="257" width="70" height="28" fill="#444474" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#444474</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b29562" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b29562</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#f9edcd" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#f9edcd</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7ca462" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ca462</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.06</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c5938" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c5938</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#573b3c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#573b3c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#986b57" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#986b57</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#354a7c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#354a7c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#444474" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#444474</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
   </g>
   <g transform="translate(0,25012)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sethos</text>
@@ -8157,31 +8157,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#2e9a41</text>
     <rect x="150" y="257" width="70" height="28" fill="#298c31" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#298c31</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c17b2a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c17b2a</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#faeab2" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#faeab2</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#976b67" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#976b67</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#3844c4" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3844c4</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#563da9" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#563da9</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#2e9a41" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#2e9a41</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#298c31" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#298c31</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
   </g>
   <g transform="translate(0,25364)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Shenhe</text>
@@ -8270,31 +8270,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#d3d5d2</text>
     <rect x="150" y="257" width="70" height="28" fill="#a4a484" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a4a484</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#86b8ca" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b8ca</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2e3f53" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e3f53</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7393ab" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7393ab</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d23e35" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d23e35</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c5805c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c5805c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b89074" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b89074</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a4a484" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a484</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d3d5d2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d3d5d2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.25</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
   </g>
   <g transform="translate(0,25716)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">ShikanoinHeizou</text>
@@ -8385,31 +8385,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#a9aea8</text>
     <rect x="150" y="257" width="70" height="28" fill="#158480" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#158480</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c74c29" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c74c29</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#883910" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#883910</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b4864b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4864b</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4f1c2a" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f1c2a</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3f3335" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3f3335</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.10</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9d94a4" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d94a4</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#158480" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#158480</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a9aea8" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a9aea8</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.23</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
   </g>
   <g transform="translate(0,26068)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sigewinne</text>
@@ -8498,31 +8498,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#d2af91</text>
     <rect x="220" y="257" width="70" height="28" fill="#e8ceb8" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#e8ceb8</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7153d0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7153d0</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#57a7d1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#57a7d1</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#406697" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#406697</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ad495d" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ad495d</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e5abbf" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e5abbf</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d97f8d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d97f8d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9f7558" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f7558</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e8ceb8" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e8ceb8</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d2af91" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d2af91</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
   </g>
   <g transform="translate(0,26420)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Skirk</text>
@@ -8613,31 +8613,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#c3e4fa</text>
     <rect x="150" y="257" width="70" height="28" fill="#32b2f1" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#32b2f1</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#2c3fd9" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c3fd9</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7d9bef" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d9bef</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5246ba" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5246ba</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#88715d" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#88715d</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.95</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#533944" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#533944</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.95</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#ad9996" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#ad9996</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#32b2f1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#32b2f1</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c3e4fa" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3e4fa</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.34</text>
   </g>
   <g transform="translate(0,26772)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sucrose</text>
@@ -8727,31 +8727,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#9abfb4</text>
     <rect x="360" y="257" width="70" height="28" fill="#34a4ac" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#34a4ac</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d4947c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4947c</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ede6cc" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ede6cc</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#978066" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4e6980" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e6980</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.88</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#1f2a42" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1f2a42</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9097a0" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9097a0</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#34a4ac" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#34a4ac</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#266e5c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#266e5c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3c9494" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#3c9494</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
   </g>
   <g transform="translate(0,27124)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Tartaglia</text>
@@ -8842,31 +8842,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#cd8443</text>
     <rect x="220" y="257" width="70" height="28" fill="#b4aca4" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#b4aca4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#44ace6" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#44ace6</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#89cfeb" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#89cfeb</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.06</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#608fbc" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#608fbc</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bc3c2d" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc3c2d</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#71302e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#71302e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9c6c69" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c6c69</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#cd8443" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8443</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e1d7c8" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1d7c8</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b4aca4" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4aca4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
   </g>
   <g transform="translate(0,27476)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Thoma</text>
@@ -8956,31 +8956,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#283640</text>
     <rect x="290" y="257" width="70" height="28" fill="#585560" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#585560</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ba363e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ba363e</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#66352b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#66352b</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#945043" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#945043</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c3732d" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3732d</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f7e499" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f7e499</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a4a08a" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a08a</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9172b0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9172b0</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#283640" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#283640</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#585560" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#585560</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
   </g>
   <g transform="translate(0,27828)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Tighnari</text>
@@ -9070,31 +9070,31 @@
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#36110e</text>
     <rect x="360" y="257" width="70" height="28" fill="#1b092e" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#1b092e</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c29e30" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29e30</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2b7755" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b7755</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#65b673" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#65b673</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#29c0d3" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#29c0d3</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#253c60" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#253c60</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6c66ac" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c66ac</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ab3c5c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ab3c5c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#1b092e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1b092e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7d563e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d563e</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
   </g>
   <g transform="translate(0,28180)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Varesa</text>
@@ -9184,31 +9184,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#448275</text>
     <rect x="290" y="257" width="70" height="28" fill="#599195" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#599195</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#a64743" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a64743</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ec8c89" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ec8c89</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.04</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c86e67" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c86e67</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b59764" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b59764</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f2e4c2" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f2e4c2</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7e6340" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6340</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#51c7b4" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#51c7b4</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#448275" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#448275</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#599195" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#599195</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
   </g>
   <g transform="translate(0,28532)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Venti</text>
@@ -9298,31 +9298,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#284f72</text>
     <rect x="290" y="257" width="70" height="28" fill="#44477c" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#44477c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#806e38" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#806e38</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#cab588" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#cab588</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#968664" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#968664</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#33a18c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#33a18c</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#2f806d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2f806d</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#627e85" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#627e85</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#1075a9" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1075a9</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#284f72" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#284f72</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#44477c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#44477c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
   </g>
   <g transform="translate(0,28884)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Wanderer</text>
@@ -9412,31 +9412,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#100a0d</text>
     <rect x="220" y="257" width="70" height="28" fill="#ae6149" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ae6149</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3caca4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3caca4</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#08173c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#08173c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#588dbd" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#588dbd</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b38253" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b38253</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c19f7d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c19f7d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#866d57" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#866d57</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ae6149" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae6149</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#100a0d" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#100a0d</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#564949" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#564949</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
   </g>
   <g transform="translate(0,29236)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Wriothesley</text>
@@ -9526,23 +9526,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#595c5b" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#595c5b</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#393b4f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#393b4f</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.10</text>
-    <rect x="144" y="305" width="124" height="30" fill="#2f303e" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2f303e</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.05</text>
+    <rect x="144" y="305" width="124" height="30" fill="#746c7e" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#746c7e</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
     <rect x="268" y="305" width="124" height="30" fill="#b52438" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52438</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="392" y="305" width="124" height="30" fill="#6b1828" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6b1828</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
+    <rect x="392" y="305" width="124" height="30" fill="#a96d58" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#a96d58</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.03</text>
     <rect x="516" y="305" width="124" height="30" fill="#595c5b" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#595c5b</text>
@@ -9637,31 +9637,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#38663f</text>
     <rect x="150" y="257" width="70" height="28" fill="#4c9464" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#4c9464</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c68733" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c68733</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#f7da9a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#f7da9a</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c36050" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c36050</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#46699e" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#46699e</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9cb4d4" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9cb4d4</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#394b73" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#394b73</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4c9464" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4c9464</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#38663f" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#38663f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
   </g>
   <g transform="translate(0,29940)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xianyun</text>
@@ -9750,31 +9750,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2d3b4e</text>
     <rect x="290" y="257" width="70" height="28" fill="#070b0f" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#070b0f</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c75531" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c75531</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ce8747" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ce8747</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#856c59" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#856c59</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7ac1b0" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7ac1b0</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d0e4ca" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d0e4ca</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6ca46c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca46c</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#458da1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#458da1</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2d3b4e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d3b4e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3d556d" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d556d</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
   </g>
   <g transform="translate(0,30292)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xiao</text>
@@ -9864,31 +9864,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#b5907a</text>
     <rect x="220" y="257" width="70" height="28" fill="#b98740" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#b98740</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b04663" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b04663</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#1c132c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c132c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#605c8c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#605c8c</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6ecba5" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ecba5</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#0c3a31" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0c3a31</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#518b8c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#518b8c</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b98740" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b98740</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b5907a" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5907a</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
   </g>
   <g transform="translate(0,30644)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xilonen</text>
@@ -9979,23 +9979,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#543c84" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#543c84</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#e2831c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2831c</text>
     <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="144" y="305" width="124" height="30" fill="#713514" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#713514</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
+    <rect x="144" y="305" width="124" height="30" fill="#9b794a" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b794a</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="268" y="305" width="124" height="30" fill="#22b6a7" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#22b6a7</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="392" y="305" width="124" height="30" fill="#276a62" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#276a62</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="392" y="305" width="124" height="30" fill="#3b868d" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#3b868d</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="516" y="305" width="124" height="30" fill="#543c84" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#543c84</text>
@@ -10090,31 +10090,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#1c2028</text>
     <rect x="150" y="257" width="70" height="28" fill="#7f96b7" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#7f96b7</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c25e13" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#c25e13</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#863908" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#863908</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#978066" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#978066</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#42657c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#42657c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#2d475d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d475d</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#597b8d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#597b8d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7f96b7" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f96b7</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#1c2028" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1c2028</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.97</text>
   </g>
   <g transform="translate(0,31348)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Xinyan</text>
@@ -10205,31 +10205,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3b2e34</text>
     <rect x="290" y="257" width="70" height="28" fill="#3c3444" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3c3444</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b93f2e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b93f2e</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#77130a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#77130a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#907361" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#907361</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#fcc841" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#fcc841</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#ede7d7" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#ede7d7</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3c3c36" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c3c36</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3c3444" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c3444</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.18</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#261719" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#261719</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3b2e34" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3b2e34</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
   </g>
   <g transform="translate(0,31700)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">YaeMiko</text>
@@ -10320,23 +10320,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#b4c4c4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#b4c4c4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#951b26" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#951b26</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="144" y="305" width="124" height="30" fill="#ecc474" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#ecc474</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <rect x="144" y="305" width="124" height="30" fill="#b64e70" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b64e70</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="268" y="305" width="124" height="30" fill="#534ba1" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#534ba1</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="392" y="305" width="124" height="30" fill="#402838" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#402838</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
+    <rect x="392" y="305" width="124" height="30" fill="#5c6494" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6494</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
     <rect x="516" y="305" width="124" height="30" fill="#b4c4c4" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4c4c4</text>
@@ -10430,31 +10430,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#307066</text>
     <rect x="220" y="257" width="70" height="28" fill="#44848c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#44848c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d4a886" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4a886</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#fbebda" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#fbebda</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b58d69" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58d69</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b0425c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0425c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#752d33" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#752d33</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b15e5e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b15e5e</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3da792" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3da792</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#307066" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#307066</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#44848c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#44848c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
   </g>
   <g transform="translate(0,32404)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yaoyao</text>
@@ -10544,31 +10544,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6c547c</text>
     <rect x="220" y="257" width="70" height="28" fill="#94a4c4" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#94a4c4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#eb9d1b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#eb9d1b</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#efce62" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#efce62</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9c9551" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c9551</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#874f33" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#874f33</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a27243" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a27243</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6c547c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c547c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#94a4c4" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#94a4c4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#61647c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#61647c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
   </g>
   <g transform="translate(0,32756)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yelan</text>
@@ -10657,31 +10657,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a98165</text>
     <rect x="220" y="257" width="70" height="28" fill="#ac6454" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#ac6454</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5665be" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5665be</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#050410" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#050410</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5c5f91" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c5f91</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#ac8f95" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8f95</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.11</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4d404b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4d404b</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#766363" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#766363</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#ac6454" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac6454</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c7ac97" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7ac97</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a98165" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a98165</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.08</text>
   </g>
   <g transform="translate(0,33108)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yoimiya</text>
@@ -10772,31 +10772,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#495494</text>
     <rect x="290" y="257" width="70" height="28" fill="#99bcbe" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#99bcbe</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bf4333" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bf4333</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#952d26" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#952d26</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b16745" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b16745</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#e4be54" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e4be54</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f3c581" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f3c581</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d19c70" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d19c70</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#495494" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#495494</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#99bcbe" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#99bcbe</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4b7476" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b7476</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
   </g>
   <g transform="translate(0,33460)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">YumemizukiMizuki</text>
@@ -10887,31 +10887,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#caa685</text>
     <rect x="360" y="257" width="70" height="28" fill="#e3bdb2" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#e3bdb2</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7941cf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7941cf</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2a1d46" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2a1d46</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a96faf" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a96faf</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4484cc" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4484cc</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3c41ae" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3c41ae</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6a79aa" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#6a79aa</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#62201d" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#62201d</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e3bdb2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3bdb2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8f6c55" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f6c55</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
   </g>
   <g transform="translate(0,33812)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yunjin</text>
@@ -11001,31 +11001,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#e08d3c</text>
     <rect x="220" y="257" width="70" height="28" fill="#716d66" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#716d66</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#86b3ca" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b3ca</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#10152b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#10152b</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#616f92" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#616f92</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c43e4e" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c43e4e</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c9768c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c9768c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#915f6f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#915f6f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#e08d3c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#e08d3c</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c2a082" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2a082</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.74</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
   </g>
   <g transform="translate(0,34164)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Zhongli</text>
@@ -11114,30 +11114,30 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#322b36</text>
     <rect x="290" y="257" width="70" height="28" fill="#413d57" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#413d57</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#a47538" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#a47538</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e5d8b9" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e5d8b9</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b8a082" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b8a082</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a04210" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a04210</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4e3425" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4e3425</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#413d57" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#413d57</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.05</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#322b36" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#322b36</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.11</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9294a5" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9294a5</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
   </g>
 </svg>

--- a/debug/palettes/colorthief/starrail.svg
+++ b/debug/palettes/colorthief/starrail.svg
@@ -88,22 +88,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#696569" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#696569</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7d79bb" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7d79bb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d79bb</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a4a0d2" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a0d2</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.36</text>
-    <rect x="330" y="305" width="155" height="30" fill="#d82a38" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d82a38</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.44</text>
-    <rect x="485" y="305" width="155" height="30" fill="#cc7679" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc7679</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d79bb</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a4a0d2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a0d2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.36</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d82a38" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d82a38</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.44</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#cc7679" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc7679</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#402537" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#402537</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.68</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e0ccd7" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0ccd7</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.89</text>
   </g>
   <g transform="translate(0,372)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Aglaea</text>
@@ -303,26 +311,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#5ca46c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#5ca46c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#4b8eb1" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4b8eb1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#4b8eb1</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.18</text>
-    <rect x="144" y="305" width="124" height="30" fill="#507993" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#507993</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
-    <rect x="268" y="305" width="124" height="30" fill="#b22835" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b22835</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
-    <rect x="392" y="305" width="124" height="30" fill="#ae967d" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae967d</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.79</text>
-    <rect x="516" y="305" width="124" height="30" fill="#5ca46c" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#5ca46c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#4b8eb1</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.18</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#507993" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#507993</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b22835" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b22835</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#ae967d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae967d</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.79</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5ca46c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#5ca46c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cbdcd4" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cbdcd4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.34</text>
   </g>
   <g transform="translate(0,1076)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Archer</text>
@@ -413,18 +425,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#3a2c34" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3a2c34</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#b47c44" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b47c44" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47c44</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
-    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#c7a890" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7a890</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
-    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#8a0c1c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="536.6666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a0c1c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.16</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47c44</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c7a890" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7a890</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8a0c1c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a0c1c</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.16</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dbd3d4" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dbd3d4</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.20</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8c848c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c848c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.18</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3a2c34" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a2c34</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.74</text>
   </g>
   <g transform="translate(0,1428)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Argenti</text>
@@ -515,14 +539,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#322932" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#322932</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#dd6365" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#dd6365" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#dd6365</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
-    <rect x="330" y="305" width="310" height="30" fill="#7d6c64" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d6c64</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.69</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#dd6365</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7d6c64" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d6c64</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.69</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d1b99c" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1b99c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.83</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a19990" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a19990</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.61</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8a8591" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a8591</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#504955" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#504955</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
   </g>
   <g transform="translate(0,1780)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Aventurine</text>
@@ -612,14 +652,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#5c6c6c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5c6c6c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#b4646c" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b4646c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4646c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
-    <rect x="330" y="305" width="310" height="30" fill="#867e7f" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#867e7f</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.25</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4646c</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#867e7f" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#867e7f</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.25</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9698ae" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9698ae</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.29</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4d6b7c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4d6b7c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.49</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#304446" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#304446</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.70</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5c6c6c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6c6c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.92</text>
   </g>
   <g transform="translate(0,2132)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">BlackSwan</text>
@@ -723,10 +779,10 @@
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc648f</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.66</text>
-    <rect x="392" y="305" width="124" height="30" fill="#826890" rx="3"/>
+    <rect x="392" y="305" width="124" height="30" fill="#d8ccf2" rx="3"/>
     <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826890</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8ccf2</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.50</text>
     <rect x="516" y="305" width="124" height="30" fill="#bf935d" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf935d</text>
@@ -821,14 +877,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#78b6a9" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#78b6a9</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#b4371b" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#b4371b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b4371b</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.87</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b29178" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b29178</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.84</text>
+    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b4371b</text>
+    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.87</text>
+    <rect x="144" y="305" width="124" height="30" fill="#b29178" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#b29178</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.84</text>
+    <rect x="268" y="305" width="124" height="30" fill="#918f9c" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#918f9c</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.31</text>
+    <rect x="392" y="305" width="124" height="30" fill="#5a6973" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5a6973</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.25</text>
+    <rect x="516" y="305" width="124" height="30" fill="#78b6a9" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#78b6a9</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
   </g>
   <g transform="translate(0,2836)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Boothill</text>
@@ -919,21 +987,29 @@
     <rect x="150" y="257" width="70" height="28" fill="#666f70" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#666f70</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c23035" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c23035" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23035</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
-    <rect x="175" y="305" width="155" height="30" fill="#bd7786" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bd7786</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.25</text>
-    <rect x="330" y="305" width="155" height="30" fill="#86b47a" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b47a</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.53</text>
-    <rect x="485" y="305" width="155" height="30" fill="#666f70" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666f70</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23035</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#bd7786" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#bd7786</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.25</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8786a4" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8786a4</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.62</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4b4350" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b4350</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#86b47a" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b47a</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.53</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#666f70" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666f70</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.87</text>
   </g>
   <g transform="translate(0,3188)">
@@ -1369,22 +1445,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#5cecfc" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#5cecfc</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#9d3fe5" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#9d3fe5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d3fe5</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a791c8" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a791c8</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.90</text>
-    <rect x="330" y="305" width="155" height="30" fill="#c16ab8" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c16ab8</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
-    <rect x="485" y="305" width="155" height="30" fill="#b3869f" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3869f</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d3fe5</text>
+    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="144" y="305" width="124" height="30" fill="#a791c8" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#a791c8</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.90</text>
+    <rect x="268" y="305" width="124" height="30" fill="#c16ab8" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#c16ab8</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
+    <rect x="392" y="305" width="124" height="30" fill="#b3869f" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3869f</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <rect x="516" y="305" width="124" height="30" fill="#5cecfc" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#5cecfc</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
   </g>
   <g transform="translate(0,4596)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">DrRatio</text>
@@ -1475,21 +1555,29 @@
     <rect x="360" y="257" width="70" height="28" fill="#d42f1c" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#d42f1c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#5773d2" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5773d2" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5773d2</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.87</text>
-    <rect x="175" y="305" width="155" height="30" fill="#707792" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#707792</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
-    <rect x="330" y="305" width="155" height="30" fill="#d42f1c" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d42f1c</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
-    <rect x="485" y="305" width="155" height="30" fill="#d9c8c1" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9c8c1</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5773d2</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.87</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#707792" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#707792</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8183" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8183</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.99</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#261c1e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#261c1e</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.91</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d42f1c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d42f1c</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d9c8c1" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9c8c1</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.55</text>
   </g>
   <g transform="translate(0,4948)">
@@ -1580,14 +1668,30 @@
     <rect x="360" y="257" width="70" height="28" fill="#213040" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#213040</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c01a18" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c01a18" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01a18</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
-    <rect x="330" y="305" width="310" height="30" fill="#7e7068" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e7068</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01a18</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7e7068" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e7068</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#4c7d84" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c7d84</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.96</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3d5a5f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d5a5f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.71</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5287ab" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#5287ab</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.93</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#34627c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#34627c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
   </g>
   <g transform="translate(0,5300)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Firefly</text>
@@ -1678,13 +1782,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#d1ab78" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#d1ab78</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#d4954f" rx="3"/>
-    <text x="24" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4954f</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.37</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b99486" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b99486</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#87afb8" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#87afb8</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.21</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#4f7287" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f7287</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7c7cac" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7c7cac</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.82</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#857c82" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#857c82</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d4954f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4954f</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.37</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b99486" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b99486</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.58</text>
   </g>
   <g transform="translate(0,5652)">
@@ -1777,14 +1897,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#f0d094" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#f0d094</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#8f5897" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#8f5897" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f5897</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
-    <rect x="330" y="305" width="310" height="30" fill="#9e83a8" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e83a8</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.87</text>
+    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f5897</text>
+    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="144" y="305" width="124" height="30" fill="#9e83a8" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e83a8</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.87</text>
+    <rect x="268" y="305" width="124" height="30" fill="#885963" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#885963</text>
+    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.06</text>
+    <rect x="392" y="305" width="124" height="30" fill="#603941" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#603941</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.22</text>
+    <rect x="516" y="305" width="124" height="30" fill="#f0d094" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#f0d094</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.95</text>
   </g>
   <g transform="translate(0,6004)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gallagher</text>
@@ -1875,14 +2007,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#9e7e5c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#9e7e5c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#b6136d" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b6136d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6136d</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b5658c" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5658c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6136d</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b5658c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5658c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7f7c95" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f7c95</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.28</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8b949e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8b949e</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#a68c70" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a68c70</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.84</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d6bcba" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d6bcba</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
   </g>
   <g transform="translate(0,6356)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gepard</text>
@@ -1974,14 +2122,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#3e3b4b" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3e3b4b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#3285ef" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3285ef" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#3285ef</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
-    <rect x="330" y="305" width="310" height="30" fill="#424c5f" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#424c5f</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#3285ef</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#222841" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#222841</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a37753" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a37753</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.89</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#998079" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#998079</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.85</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bebac2" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bebac2</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.31</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3e3b4b" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3e3b4b</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.65</text>
   </g>
   <g transform="translate(0,6708)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Guinaifen</text>
@@ -2073,22 +2237,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#68b4c2" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#68b4c2</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#aa4f4e" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#aa4f4e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#aa4f4e</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.54</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a494a9" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a494a9</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
-    <rect x="330" y="305" width="155" height="30" fill="#d46b5f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d46b5f</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
-    <rect x="485" y="305" width="155" height="30" fill="#a08780" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a08780</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#aa4f4e</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.54</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a494a9" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a494a9</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d46b5f" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d46b5f</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a08780" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a08780</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#387c8e" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#387c8e</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.50</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#68b4c2" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#68b4c2</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
   </g>
   <g transform="translate(0,7060)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Hanya</text>
@@ -2178,21 +2350,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#534c45" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#534c45</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#c52a34" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c52a34</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.19</text>
-    <rect x="175" y="305" width="155" height="30" fill="#926d67" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#926d67</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.09</text>
-    <rect x="330" y="305" width="155" height="30" fill="#c29461" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29461</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.02</text>
-    <rect x="485" y="305" width="155" height="30" fill="#ccae8c" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ccae8c</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#758fac" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#758fac</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.80</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#69737f" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#69737f</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.28</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c52a34" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c52a34</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.19</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#926d67" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#926d67</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.09</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c29461" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29461</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.02</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#ccae8c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ccae8c</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
   </g>
   <g transform="translate(0,7412)">
@@ -2285,14 +2465,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#445464" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#445464</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#e27167" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#e27167" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e27167</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b39189" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b39189</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.99</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#e27167</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b39189" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b39189</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.99</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c0a0b2" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0a0b2</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#826f7b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826f7b</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8cb8cc" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8cb8cc</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.18</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#446474" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#446474</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
   </g>
   <g transform="translate(0,7764)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Huohuo</text>
@@ -2384,14 +2580,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#37666a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#37666a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c73d34" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c73d34" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c73d34</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
-    <rect x="330" y="305" width="310" height="30" fill="#98828b" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#98828b</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.72</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c73d34</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#98828b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#98828b</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.72</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#99a1c0" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#99a1c0</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#636e8f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#636e8f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.34</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5b8f8c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8f8c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.36</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9bc3b3" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9bc3b3</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.07</text>
   </g>
   <g transform="translate(0,8116)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Hyacine</text>
@@ -2498,14 +2710,14 @@
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3afc1</text>
     <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.15</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#48a4c1" rx="3"/>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7193ae" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#48a4c1</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7193ae" rx="3"/>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7193ae</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.82</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#48a4c1" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7193ae</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.75</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#48a4c1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
   </g>
   <g transform="translate(0,8468)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jade</text>
@@ -2709,14 +2921,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#686560" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#686560</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#b1363a" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#b1363a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b1363a</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.63</text>
-    <rect x="330" y="305" width="310" height="30" fill="#b18b7f" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b18b7f</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.82</text>
+    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b1363a</text>
+    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.63</text>
+    <rect x="144" y="305" width="124" height="30" fill="#b18b7f" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#b18b7f</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.82</text>
+    <rect x="268" y="305" width="124" height="30" fill="#688da7" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#688da7</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.74</text>
+    <rect x="392" y="305" width="124" height="30" fill="#8aa7b4" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#8aa7b4</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.70</text>
+    <rect x="516" y="305" width="124" height="30" fill="#686560" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#686560</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.28</text>
   </g>
   <g transform="translate(0,9172)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">JingYuan</text>
@@ -2807,17 +3031,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#6ca0cc" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#6ca0cc</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#7c3c54" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="123.33333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7c3c54</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.17</text>
-    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#6ca0cc" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca0cc</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
-    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#376074" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="536.6666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#376074</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#887b75" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#887b75</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.93</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b2967f" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b2967f</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7c3c54" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7c3c54</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.17</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#562a2b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#562a2b</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.31</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6ca0cc" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca0cc</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#376074" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#376074</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
   </g>
   <g transform="translate(0,9524)">
@@ -2909,21 +3145,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#b08265" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b08265</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#5f7ec0" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5f7ec0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5f7ec0</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
-    <rect x="175" y="305" width="155" height="30" fill="#8dadd1" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8dadd1</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b11012" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b11012</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
-    <rect x="485" y="305" width="155" height="30" fill="#b49b97" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b49b97</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5f7ec0</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8dadd1" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8dadd1</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#857387" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#857387</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.50</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e6e2e6" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e6e2e6</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.90</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b11012" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b11012</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b49b97" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b49b97</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.49</text>
   </g>
   <g transform="translate(0,9876)">
@@ -3020,26 +3264,26 @@
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#cb4f3a</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ac82b2" rx="3"/>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5c3a3a" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac82b2</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d8c155" rx="3"/>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c3a3a</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#84826f" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8c155</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.00</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#84826f" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#84826f</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.14</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#65624f" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#84826f</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.54</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3c8c6c" rx="3"/>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#65624f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7eb3a0" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3c8c6c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.99</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7eb3a0" rx="3"/>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7eb3a0</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.49</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3c846c" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7eb3a0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#3c846c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
   </g>
   <g transform="translate(0,10228)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Luocha</text>
@@ -3129,14 +3373,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#0b090c" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#0b090c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#c48c4c" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48c4c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.39</text>
-    <rect x="330" y="305" width="310" height="30" fill="#90846e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#90846e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.73</text>
+    <rect x="20" y="305" width="124" height="30" fill="#667d74" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#667d74</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.15</text>
+    <rect x="144" y="305" width="124" height="30" fill="#92a3a4" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#92a3a4</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="268" y="305" width="124" height="30" fill="#c48c4c" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48c4c</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.39</text>
+    <rect x="392" y="305" width="124" height="30" fill="#90846e" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#90846e</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.73</text>
+    <rect x="516" y="305" width="124" height="30" fill="#0b090c" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0b090c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=4.07</text>
   </g>
   <g transform="translate(0,10580)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">March7th</text>
@@ -3228,22 +3484,30 @@
     <rect x="360" y="257" width="70" height="28" fill="#f7e3c9" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#f7e3c9</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7590c8" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7590c8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7590c8</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
-    <rect x="175" y="305" width="155" height="30" fill="#b5b6d2" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5b6d2</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
-    <rect x="330" y="305" width="155" height="30" fill="#c67154" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67154</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
-    <rect x="485" y="305" width="155" height="30" fill="#e1b191" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1b191</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7590c8</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b5b6d2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5b6d2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b788a1" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b788a1</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.76</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d4b4be" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4b4be</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c67154" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67154</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#f8eae6" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f8eae6</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.86</text>
   </g>
   <g transform="translate(0,10932)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Moze</text>
@@ -3334,21 +3598,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#a47664" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#a47664</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7577bf" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7577bf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7577bf</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
-    <rect x="175" y="305" width="155" height="30" fill="#979fc6" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#979fc6</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
-    <rect x="330" y="305" width="155" height="30" fill="#b52d4f" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52d4f</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
-    <rect x="485" y="305" width="155" height="30" fill="#bb6990" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb6990</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7577bf</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#979fc6" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#979fc6</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#845776" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#845776</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.30</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c8c1d1" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c8c1d1</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b52d4f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52d4f</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bb6990" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb6990</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
   </g>
   <g transform="translate(0,11284)">
@@ -3441,22 +3713,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#3154b6" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3154b6</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#dd7566" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#dd7566" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#dd7566</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.62</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a17d6a" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a17d6a</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.24</text>
-    <rect x="330" y="305" width="155" height="30" fill="#3154b6" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3154b6</text>
-    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.45</text>
-    <rect x="485" y="305" width="155" height="30" fill="#9d8fb0" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8fb0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.70</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#dd7566</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.62</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a17d6a" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a17d6a</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.24</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#621f25" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#621f25</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.63</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7b5d70" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7b5d70</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.09</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9d8fb0" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8fb0</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3154b6" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3154b6</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.24</text>
   </g>
   <g transform="translate(0,11636)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Phainon</text>
@@ -3546,22 +3826,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#8c441c" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8c441c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#bf8a4a" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf8a4a</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.43</text>
-    <rect x="175" y="305" width="155" height="30" fill="#9b8069" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8069</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.71</text>
-    <rect x="330" y="305" width="155" height="30" fill="#bc7c6c" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc7c6c</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
-    <rect x="485" y="305" width="155" height="30" fill="#8c441c" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c441c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.87</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#8999c0" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#8999c0</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.86</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7f86a0" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f86a0</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.88</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9b8069" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8069</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7b6048" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7b6048</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.64</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc7c6c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc7c6c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#281a1d" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#281a1d</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.26</text>
   </g>
   <g transform="translate(0,11988)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Rappa</text>
@@ -3665,10 +3953,10 @@
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc8233</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.86</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#72df81" rx="3"/>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dada80" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#72df81</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.32</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dada80</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.60</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7e88de" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7e88de</text>
@@ -3767,22 +4055,30 @@
     <rect x="290" y="257" width="70" height="28" fill="#e5ccb3" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#e5ccb3</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#7372bb" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7372bb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7372bb</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.86</text>
-    <rect x="175" y="305" width="155" height="30" fill="#a2a6d2" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2a6d2</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.37</text>
-    <rect x="330" y="305" width="155" height="30" fill="#9e88bd" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e88bd</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.33</text>
-    <rect x="485" y="305" width="155" height="30" fill="#bdadd5" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bdadd5</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7372bb</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.86</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a2a6d2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2a6d2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.37</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9e88bd" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e88bd</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.33</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bdadd5" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bdadd5</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c9af8f" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c9af8f</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.68</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e5ccb3" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e5ccb3</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
   </g>
   <g transform="translate(0,12692)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">RuanMei</text>
@@ -3874,14 +4170,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#2d2e3a" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2d2e3a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#ca5262" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#ca5262" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ca5262</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
-    <rect x="330" y="305" width="310" height="30" fill="#99857e" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#99857e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.12</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#ca5262</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="144" y="305" width="124" height="30" fill="#99857e" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#99857e</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.12</text>
+    <rect x="268" y="305" width="124" height="30" fill="#538ea0" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#538ea0</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.79</text>
+    <rect x="392" y="305" width="124" height="30" fill="#799eb6" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#799eb6</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.53</text>
+    <rect x="516" y="305" width="124" height="30" fill="#2d2e3a" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d2e3a</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.26</text>
   </g>
   <g transform="translate(0,13044)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Saber</text>
@@ -3973,22 +4281,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#4b4c46" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#4b4c46</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#3962cd" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3962cd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3962cd</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
-    <rect x="175" y="305" width="155" height="30" fill="#958fba" rx="3"/>
-    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#958fba</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
-    <rect x="330" y="305" width="155" height="30" fill="#c18247" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c18247</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
-    <rect x="485" y="305" width="155" height="30" fill="#897067" rx="3"/>
-    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#897067</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.02</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3962cd</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#958fba" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#958fba</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c18247" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c18247</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#897067" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#897067</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.02</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4b4c46" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b4c46</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=5.73</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#686c6a" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#686c6a</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.05</text>
   </g>
   <g transform="translate(0,13396)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sparkle</text>
@@ -4084,10 +4400,10 @@
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cf263e</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.49</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#80726e" rx="3"/>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ebd3cf" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#80726e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ebd3cf</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.40</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#2972cf" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2972cf</text>
@@ -4193,6 +4509,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#bcbca4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#bcbca4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
+    <rect x="20" y="305" width="124" height="30" fill="#8f90b4" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#8f90b4</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.71</text>
+    <rect x="144" y="305" width="124" height="30" fill="#b8c0dc" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#b8c0dc</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="268" y="305" width="124" height="30" fill="#918483" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#918483</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.09</text>
+    <rect x="392" y="305" width="124" height="30" fill="#6f615e" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6f615e</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="516" y="305" width="124" height="30" fill="#bcbca4" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#bcbca4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.66</text>
   </g>
   <g transform="translate(0,14100)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">TheHerta</text>
@@ -4398,21 +4734,29 @@
     <rect x="290" y="257" width="70" height="28" fill="#bba553" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bba553</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#de4152" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#de4152</text>
-    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
-    <rect x="175" y="305" width="155" height="30" fill="#9d6578" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d6578</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
-    <rect x="330" y="305" width="155" height="30" fill="#edca48" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#edca48</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.30</text>
-    <rect x="485" y="305" width="155" height="30" fill="#807165" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#807165</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9795b6" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#9795b6</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.62</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7a6788" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a6788</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#de4152" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#de4152</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9d6578" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d6578</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#edca48" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#edca48</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.30</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#807165" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#807165</text>
     <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
   </g>
   <g transform="translate(0,14804)">
@@ -4513,22 +4857,22 @@
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1bab7</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.89</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9a5b41" rx="3"/>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b58a6b" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9a5b41</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b58a6b" rx="3"/>
+    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58a6b</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9a5b41" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58a6b</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4c6cb6" rx="3"/>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9a5b41</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.37</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9089a4" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c6cb6</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.19</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9089a4" rx="3"/>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9089a4</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d4cde3" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9089a4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.90</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4cde3</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
   </g>
   <g transform="translate(0,15156)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yunli</text>
@@ -4620,14 +4964,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#342c54" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#342c54</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="310" height="30" fill="#db573c" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#db573c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#db573c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
-    <rect x="330" y="305" width="310" height="30" fill="#a5837e" rx="3"/>
-    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5837e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.90</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#db573c</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a5837e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5837e</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.90</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#2b757a" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b757a</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.33</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#425e68" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#425e68</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.59</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#666c7b" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666c7b</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.66</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#989ead" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#989ead</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.50</text>
   </g>
   <g transform="translate(0,15508)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">kafka</text>
@@ -4717,21 +5077,29 @@
     <rect x="220" y="257" width="70" height="28" fill="#c47c7c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c47c7c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="155" height="30" fill="#9b627a" rx="3"/>
-    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9b627a</text>
-    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
-    <rect x="175" y="305" width="155" height="30" fill="#7a6d70" rx="3"/>
-    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a6d70</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.05</text>
-    <rect x="330" y="305" width="155" height="30" fill="#c47c7c" rx="3"/>
-    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47c7c</text>
-    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.28</text>
-    <rect x="485" y="305" width="155" height="30" fill="#c29196" rx="3"/>
-    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29196</text>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6c4762" rx="3"/>
+    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
+    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c4762</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.76</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ac98ad" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac98ad</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9b627a" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9b627a</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7a6d70" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a6d70</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.05</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c47c7c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47c7c</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.28</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c29196" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29196</text>
     <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.50</text>
   </g>
 </svg>

--- a/debug/palettes/colorthief/starrail.svg
+++ b/debug/palettes/colorthief/starrail.svg
@@ -87,31 +87,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#402537</text>
     <rect x="220" y="257" width="70" height="28" fill="#696569" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#696569</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3135ac" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3135ac</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#141331" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#141331</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#585285" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#585285</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d82a38" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d82a38</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#470b11" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#470b11</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c9675a" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c9675a</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#402537" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#402537</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e0ccd7" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e0ccd7</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#696569" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#696569</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
   </g>
   <g transform="translate(0,372)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Aglaea</text>
@@ -201,23 +201,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#cf80f2" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#cf80f2</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#a77d36" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#a77d36</text>
     <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="144" y="305" width="124" height="30" fill="#faeab7" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#faeab7</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <rect x="144" y="305" width="124" height="30" fill="#8e785a" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e785a</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="268" y="305" width="124" height="30" fill="#3094b4" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#3094b4</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="392" y="305" width="124" height="30" fill="#3dc9d2" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#3dc9d2</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
     <rect x="516" y="305" width="124" height="30" fill="#cf80f2" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#cf80f2</text>
@@ -310,31 +310,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#cbdcd4</text>
     <rect x="150" y="257" width="70" height="28" fill="#5ca46c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#5ca46c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#1f476b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1f476b</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#83c2cd" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#83c2cd</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#507993" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#507993</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b22835" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b22835</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b08956" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08956</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.88</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5ca46c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#5ca46c</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cbdcd4" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cbdcd4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
   </g>
   <g transform="translate(0,1076)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Archer</text>
@@ -424,31 +424,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#584c54</text>
     <rect x="220" y="257" width="70" height="28" fill="#3a2c34" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3a2c34</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b47c44" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47c44</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c7a890" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7a890</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ae7447" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae7447</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8a0c1c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a0c1c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#69141e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#69141e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#584c54" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584c54</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.21</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3a2c34" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a2c34</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.05</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c848c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c848c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
   </g>
   <g transform="translate(0,1428)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Argenti</text>
@@ -538,31 +538,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#504955</text>
     <rect x="220" y="257" width="70" height="28" fill="#322932" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#322932</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c52a2f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c52a2f</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7b1f18" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7b1f18</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7d6c64" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d6c64</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d1b99c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1b99c</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#f8ecdc" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#f8ecdc</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a19990" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a19990</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#504955" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#504955</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.20</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#322932" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#322932</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8a8591" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a8591</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
   </g>
   <g transform="translate(0,1780)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Aventurine</text>
@@ -651,31 +651,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#304446</text>
     <rect x="150" y="257" width="70" height="28" fill="#5c6c6c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5c6c6c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ac8250" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8250</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7d6237" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d6237</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b4646c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4646c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#1d405b" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1d405b</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#262c42" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#262c42</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4d6b7c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4d6b7c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#304446" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#304446</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.11</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5c6c6c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6c6c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.19</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
   </g>
   <g transform="translate(0,2132)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">BlackSwan</text>
@@ -766,23 +766,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#bf935d" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#bf935d</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#2e4ad7" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e4ad7</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="144" y="305" width="124" height="30" fill="#9ba1ee" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#9ba1ee</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
+    <rect x="144" y="305" width="124" height="30" fill="#5143a3" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5143a3</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="268" y="305" width="124" height="30" fill="#bc648f" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc648f</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
-    <rect x="392" y="305" width="124" height="30" fill="#b28fe1" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b28fe1</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <rect x="392" y="305" width="124" height="30" fill="#826890" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826890</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="516" y="305" width="124" height="30" fill="#bf935d" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf935d</text>
@@ -876,23 +876,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#78b6a9" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#78b6a9</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#b4371b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b4371b</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="144" y="305" width="124" height="30" fill="#7a1e0c" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a1e0c</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
+    <rect x="144" y="305" width="124" height="30" fill="#b29178" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#b29178</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="268" y="305" width="124" height="30" fill="#314657" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#314657</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
-    <rect x="392" y="305" width="124" height="30" fill="#353650" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#353650</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
+    <rect x="392" y="305" width="124" height="30" fill="#5a6973" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5a6973</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
     <rect x="516" y="305" width="124" height="30" fill="#78b6a9" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#78b6a9</text>
@@ -986,31 +986,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#86b47a</text>
     <rect x="150" y="257" width="70" height="28" fill="#666f70" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#666f70</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c23035" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23035</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#310606" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#310606</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#815b54" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#815b54</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8786a4" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8786a4</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.09</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4b4350" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b4350</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#615c6e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#615c6e</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#86b47a" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b47a</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#666f70" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666f70</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.26</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
   </g>
   <g transform="translate(0,3188)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Bronya</text>
@@ -1101,31 +1101,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5c6565</text>
     <rect x="220" y="257" width="70" height="28" fill="#3a4546" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3a4546</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#406fc5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#406fc5</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2f3c8c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2f3c8c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b0272f" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0272f</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c0a280" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0a280</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a7815c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a7815c</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.03</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#71bfe6" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#71bfe6</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3a4546" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3a4546</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.13</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5c6565" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6565</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
   </g>
   <g transform="translate(0,3540)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Castorice</text>
@@ -1216,31 +1216,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2d56ac</text>
     <rect x="220" y="257" width="70" height="28" fill="#8cbcfc" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8cbcfc</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f256d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f256d</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b491d9" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b491d9</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6a5491" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a5491</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bcbc6c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bcbc6c</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#584739" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584739</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3193d3" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3193d3</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8cbcfc" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8cbcfc</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2d56ac" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d56ac</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
   </g>
   <g transform="translate(0,3892)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Cipher</text>
@@ -1331,31 +1331,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#cc8781</text>
     <rect x="220" y="257" width="70" height="28" fill="#c45c59" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c45c59</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#286ac8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#286ac8</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7988c1" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7988c1</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#414b8d" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#414b8d</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd8b40" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8b40</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e1c1a7" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1c1a7</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9f816f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f816f</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c45c59" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c45c59</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cc8781" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc8781</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
   </g>
   <g transform="translate(0,4244)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Cyrene</text>
@@ -1444,23 +1444,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#5cecfc" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#5cecfc</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#9d3fe5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d3fe5</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
-    <rect x="144" y="305" width="124" height="30" fill="#eab9ef" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#eab9ef</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
+    <rect x="144" y="305" width="124" height="30" fill="#7e70b4" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#7e70b4</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="268" y="305" width="124" height="30" fill="#d4549c" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4549c</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="392" y="305" width="124" height="30" fill="#eb96cd" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#eb96cd</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
+    <rect x="392" y="305" width="124" height="30" fill="#966384" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#966384</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="516" y="305" width="124" height="30" fill="#5cecfc" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#5cecfc</text>
@@ -1554,31 +1554,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b37f6e</text>
     <rect x="360" y="257" width="70" height="28" fill="#d42f1c" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#d42f1c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5773d2" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5773d2</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#282b55" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#282b55</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#44479d" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#44479d</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8183" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8183</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.21</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#261c1e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#261c1e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.98</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d42f1c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d42f1c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c2833b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c2833b</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b37f6e" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b37f6e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
   </g>
   <g transform="translate(0,4948)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Feixiao</text>
@@ -1667,31 +1667,31 @@
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#284459</text>
     <rect x="360" y="257" width="70" height="28" fill="#213040" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#213040</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c01a18" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01a18</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#c8ad88" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c8ad88</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ac875c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac875c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7fbec7" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7fbec7</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4c7d84" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c7d84</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#34627c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#34627c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#284459" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#284459</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5287ab" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#5287ab</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
   </g>
   <g transform="translate(0,5300)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Firefly</text>
@@ -1781,31 +1781,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#b99486</text>
     <rect x="290" y="257" width="70" height="28" fill="#d1ab78" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#d1ab78</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f7287" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f7287</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#334258" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#334258</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#87afb8" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#87afb8</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7c7cac" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7c7cac</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e3e0ea" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e3e0ea</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#857c82" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#857c82</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d4954f" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4954f</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d1ab78" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1ab78</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b99486" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b99486</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
   </g>
   <g transform="translate(0,5652)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">FuXuan</text>
@@ -1896,23 +1896,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#f0d094" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#f0d094</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#4c1d84" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c1d84</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="144" y="305" width="124" height="30" fill="#682476" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#682476</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <rect x="144" y="305" width="124" height="30" fill="#8f5897" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f5897</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="268" y="305" width="124" height="30" fill="#885963" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#885963</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
     <rect x="392" y="305" width="124" height="30" fill="#603941" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#603941</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
     <rect x="516" y="305" width="124" height="30" fill="#f0d094" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#f0d094</text>
@@ -2006,31 +2006,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#a68c70</text>
     <rect x="220" y="257" width="70" height="28" fill="#9e7e5c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#9e7e5c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b6136d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6136d</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#3f0f28" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3f0f28</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b5658c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5658c</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#474c69" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#474c69</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.99</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#261f38" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#261f38</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7f7c95" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f7c95</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9e7e5c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e7e5c</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d6bcba" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d6bcba</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a68c70" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a68c70</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
   </g>
   <g transform="translate(0,6356)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gepard</text>
@@ -2121,31 +2121,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#110f14</text>
     <rect x="220" y="257" width="70" height="28" fill="#3e3b4b" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3e3b4b</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#1834a1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1834a1</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#203177" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#203177</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#424c5f" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#424c5f</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a37753" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a37753</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#945c4c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#945c4c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3e3b4b" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3e3b4b</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.18</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#110f14" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#110f14</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.15</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bebac2" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bebac2</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
   </g>
   <g transform="translate(0,6708)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Guinaifen</text>
@@ -2236,31 +2236,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#387c8e</text>
     <rect x="150" y="257" width="70" height="28" fill="#68b4c2" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#68b4c2</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#88373a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#88373a</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5f282d" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5f282d</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#aa4f4e" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#aa4f4e</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d46b5f" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d46b5f</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e2b78b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e2b78b</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7e6255" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6255</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#387c8e" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#387c8e</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#68b4c2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#68b4c2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
   </g>
   <g transform="translate(0,7060)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Hanya</text>
@@ -2349,31 +2349,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c29461</text>
     <rect x="290" y="257" width="70" height="28" fill="#534c45" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#534c45</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#395a7f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#395a7f</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2e435e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e435e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#758fac" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#758fac</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c52a34" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c52a34</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c29789" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29789</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#926d67" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#926d67</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c29461" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29461</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#ccae8c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ccae8c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
   </g>
   <g transform="translate(0,7412)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Himekc</text>
@@ -2464,31 +2464,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#446474</text>
     <rect x="220" y="257" width="70" height="28" fill="#445464" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#445464</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9f171e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9f171e</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e9bc80" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e9bc80</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#914e41" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#914e41</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#583e43" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#583e43</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c0a0b2" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c0a0b2</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#826f7b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826f7b</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8cb8cc" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8cb8cc</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#446474" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#446474</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
   </g>
   <g transform="translate(0,7764)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Huohuo</text>
@@ -2579,31 +2579,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#5b8f8c</text>
     <rect x="220" y="257" width="70" height="28" fill="#37666a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#37666a</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#981d1c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#981d1c</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#dcae84" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#dcae84</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#98828b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#98828b</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#354d6a" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#354d6a</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#24303c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#24303c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#636e8f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#636e8f</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#37666a" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#37666a</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9bc3b3" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9bc3b3</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5b8f8c" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8f8c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
   </g>
   <g transform="translate(0,8116)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Hyacine</text>
@@ -2693,31 +2693,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#48a4c1</text>
     <rect x="220" y="257" width="70" height="28" fill="#3f73aa" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3f73aa</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bf2e53" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bf2e53</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#751c34" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#751c34</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#926478" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926478</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b427d5" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b427d5</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dcccec" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dcccec</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9b93ac" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b93ac</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#48a4c1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#48a4c1</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3f73aa" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3f73aa</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7193ae" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7193ae</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
   </g>
   <g transform="translate(0,8468)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jade</text>
@@ -2807,31 +2807,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#c44242</text>
     <rect x="220" y="257" width="70" height="28" fill="#d08c51" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#d08c51</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#665dcf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#665dcf</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8dabdb" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8dabdb</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#745f93" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#745f93</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b572b0" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b572b0</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d7bfc6" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7bfc6</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#875f6c" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#875f6c</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c44242" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c44242</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#d08c51" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d08c51</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#ba8e80" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ba8e80</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
   </g>
   <g transform="translate(0,8820)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jiaoqiu</text>
@@ -2920,23 +2920,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#686560" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#686560</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#b1363a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b1363a</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="144" y="305" width="124" height="30" fill="#5d2e32" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d2e32</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <rect x="144" y="305" width="124" height="30" fill="#ae565c" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae565c</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
     <rect x="268" y="305" width="124" height="30" fill="#45647c" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#45647c</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
-    <rect x="392" y="305" width="124" height="30" fill="#32475b" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#32475b</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
+    <rect x="392" y="305" width="124" height="30" fill="#688da7" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#688da7</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
     <rect x="516" y="305" width="124" height="30" fill="#686560" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#686560</text>
@@ -3030,31 +3030,31 @@
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#376074</text>
     <rect x="220" y="257" width="70" height="28" fill="#6ca0cc" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#6ca0cc</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ddba98" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ddba98</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#5c4a2f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c4a2f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b2967f" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b2967f</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7c3c54" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7c3c54</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#562a2b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#562a2b</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6ca0cc" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca0cc</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#386c7e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#386c7e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
   </g>
   <g transform="translate(0,9524)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jingliu</text>
@@ -3144,31 +3144,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#cfb09e</text>
     <rect x="290" y="257" width="70" height="28" fill="#b08265" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b08265</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5f7ec0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5f7ec0</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#091140" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#091140</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#60729a" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#60729a</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#857387" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#857387</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.15</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#180d19" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#180d19</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#5e505d" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5e505d</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b11012" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b11012</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cfb09e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cfb09e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b08265" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08265</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
   </g>
   <g transform="translate(0,9876)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lingsha</text>
@@ -3259,31 +3259,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#3c8c6c</text>
     <rect x="220" y="257" width="70" height="28" fill="#3c846c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#3c846c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ae3724" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae3724</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#782212" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#782212</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.03</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ac82b2" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac82b2</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d8c155" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8c155</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#65624f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#65624f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.10</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#84826f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#84826f</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3c8c6c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3c8c6c</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#3c846c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#3c846c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7eb3a0" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7eb3a0</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
   </g>
   <g transform="translate(0,10228)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Luocha</text>
@@ -3372,23 +3372,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#0b090c" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#0b090c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#42676f" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#42676f</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.89</text>
-    <rect x="144" y="305" width="124" height="30" fill="#31484f" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#31484f</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.88</text>
+    <rect x="144" y="305" width="124" height="30" fill="#667d74" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#667d74</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
     <rect x="268" y="305" width="124" height="30" fill="#c48c4c" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48c4c</text>
     <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="392" y="305" width="124" height="30" fill="#7c5434" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7c5434</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.62</text>
+    <rect x="392" y="305" width="124" height="30" fill="#b47c64" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47c64</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
     <rect x="516" y="305" width="124" height="30" fill="#0b090c" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0b090c</text>
@@ -3483,31 +3483,31 @@
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#f4dab5</text>
     <rect x="360" y="257" width="70" height="28" fill="#f7e3c9" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#f7e3c9</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#45bdd3" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#45bdd3</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#35468a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#35468a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7754af" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7754af</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6d414c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d414c</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.89</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#e1c8d2" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1c8d2</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b788a1" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b788a1</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c67154" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67154</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#f4dab5" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f4dab5</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e1b191" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1b191</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
   </g>
   <g transform="translate(0,10932)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Moze</text>
@@ -3597,31 +3597,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#bb6990</text>
     <rect x="220" y="257" width="70" height="28" fill="#a47664" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#a47664</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f5199" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f5199</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#111338" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#111338</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#676e95" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#676e95</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#320b2e" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#320b2e</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#5d3653" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d3653</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#845776" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#845776</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b52d4f" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52d4f</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bb6990" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb6990</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a47664" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a47664</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
   </g>
   <g transform="translate(0,11284)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mydei</text>
@@ -3712,31 +3712,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#9d8fb0</text>
     <rect x="150" y="257" width="70" height="28" fill="#3154b6" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3154b6</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ca2b26" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ca2b26</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#edc9af" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#edc9af</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a17d6a" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a17d6a</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#621f25" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#621f25</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6b3d4e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6b3d4e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7b5d70" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7b5d70</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3154b6" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3154b6</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9d8fb0" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8fb0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
   </g>
   <g transform="translate(0,11636)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Phainon</text>
@@ -3825,31 +3825,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#bc7c6c</text>
     <rect x="220" y="257" width="70" height="28" fill="#8c441c" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8c441c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#506392" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#506392</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#97badb" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#97badb</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7f86a0" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f86a0</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bf8a4a" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf8a4a</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dfc190" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dfc190</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9b8069" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8069</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8c441c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c441c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bc7c6c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc7c6c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
   </g>
   <g transform="translate(0,11988)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Rappa</text>
@@ -3940,31 +3940,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#7adce9</text>
     <rect x="290" y="257" width="70" height="28" fill="#7e88de" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#7e88de</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d7303d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d7303d</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e6abf6" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e6abf6</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b87376" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b87376</text>
     <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cc8233" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc8233</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9bec6d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9bec6d</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dada80" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dada80</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4edbd3" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4edbd3</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7adce9" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7adce9</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#487bbc" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#487bbc</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
   </g>
   <g transform="translate(0,12340)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Robin</text>
@@ -4054,31 +4054,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#6a4836</text>
     <rect x="290" y="257" width="70" height="28" fill="#e5ccb3" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#e5ccb3</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4540c2" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4540c2</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2c2370" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c2370</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#644c9f" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#644c9f</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9e88bd" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e88bd</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bdadd5" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bdadd5</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6a4836" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a4836</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e5ccb3" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e5ccb3</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8b6f59" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8b6f59</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
   </g>
   <g transform="translate(0,12692)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">RuanMei</text>
@@ -4169,23 +4169,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#2d2e3a" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2d2e3a</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#d5993c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#d5993c</text>
     <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="144" y="305" width="124" height="30" fill="#e28da7" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#e28da7</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <rect x="144" y="305" width="124" height="30" fill="#99857e" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#99857e</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="268" y="305" width="124" height="30" fill="#2c4e6c" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c4e6c</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
-    <rect x="392" y="305" width="124" height="30" fill="#346376" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#346376</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
+    <rect x="392" y="305" width="124" height="30" fill="#538ea0" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#538ea0</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.06</text>
     <rect x="516" y="305" width="124" height="30" fill="#2d2e3a" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d2e3a</text>
@@ -4280,31 +4280,31 @@
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#686c6a</text>
     <rect x="150" y="257" width="70" height="28" fill="#4b4c46" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#4b4c46</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3962cd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3962cd</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#202d5f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#202d5f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.42</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#958fba" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#958fba</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b5592b" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b5592b</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#240d07" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#240d07</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#897067" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#897067</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#686c6a" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#686c6a</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.25</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4b4c46" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-DV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b4c46</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.21</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
   </g>
   <g transform="translate(0,13396)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sparkle</text>
@@ -4395,31 +4395,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#dbb48a</text>
     <rect x="150" y="257" width="70" height="28" fill="#d8a146" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#d8a146</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cf263e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cf263e</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#d4828c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4828c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a64e5c" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a64e5c</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#2972cf" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2972cf</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#92c4e1" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#92c4e1</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6d6499" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d6499</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d8a146" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8a146</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dbb48a" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dbb48a</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
   </g>
   <g transform="translate(0,13748)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sunday</text>
@@ -4508,23 +4508,23 @@
     <text x="58" y="275" fill="#666666" font-size="9">(1)</text>
     <rect x="80" y="257" width="70" height="28" fill="#bcbca4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#bcbca4</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="124" height="30" fill="#1e2765" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1e2765</text>
     <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="144" y="305" width="124" height="30" fill="#9facd9" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#9facd9</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.54</text>
+    <rect x="144" y="305" width="124" height="30" fill="#626691" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#626691</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
     <rect x="268" y="305" width="124" height="30" fill="#6d4c32" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d4c32</text>
     <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
-    <rect x="392" y="305" width="124" height="30" fill="#cca484" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#cca484</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <rect x="392" y="305" width="124" height="30" fill="#918483" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#918483</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
     <rect x="516" y="305" width="124" height="30" fill="#bcbca4" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#bcbca4</text>
@@ -4618,31 +4618,31 @@
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#b48864</text>
     <rect x="150" y="257" width="70" height="28" fill="#bc4c5c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#bc4c5c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3418b8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3418b8</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8a7cc8" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-LV</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a7cc8</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#605395" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#605395</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bd7dbf" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bd7dbf</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#110a15" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#110a15</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.85</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8c7790" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c7790</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc4c5c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc4c5c</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b48864" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48864</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
   </g>
   <g transform="translate(0,14452)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">TopazandNumby</text>
@@ -4733,31 +4733,31 @@
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#edca48</text>
     <rect x="290" y="257" width="70" height="28" fill="#bba553" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bba553</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7a6788" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a6788</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#12101d" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#12101d</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.89</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9795b6" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9795b6</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#de4152" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#de4152</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4d0b10" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4d0b10</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9d6578" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d6578</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#edca48" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#edca48</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dbb18d" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dbb18d</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bba553" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bba553</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
   </g>
   <g transform="translate(0,14804)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Tribbie</text>
@@ -4848,31 +4848,31 @@
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#4c6cb6</text>
     <rect x="290" y="257" width="70" height="28" fill="#5d389d" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5d389d</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d32e24" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d32e24</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#8f120f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f120f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#986866" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#986866</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#f49c49" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f49c49</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dea98e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-LV</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dea98e</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b58a6b" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58a6b</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5d389d" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d389d</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c6cb6" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c6cb6</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
   </g>
   <g transform="translate(0,15156)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yunli</text>
@@ -4963,31 +4963,31 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#989ead</text>
     <rect x="220" y="257" width="70" height="28" fill="#342c54" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#342c54</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#db573c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#db573c</text>
     <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6a1d1b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a1d1b</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#90605b" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#90605b</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#2b757a" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b757a</text>
     <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#1e3b48" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1e3b48</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#425e68" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#425e68</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#342c54" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#342c54</text>
     <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#989ead" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#989ead</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.12</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#666c7b" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666c7b</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
   </g>
   <g transform="translate(0,15508)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">kafka</text>
@@ -5076,30 +5076,30 @@
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#c29196</text>
     <rect x="220" y="257" width="70" height="28" fill="#c47c7c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c47c7c</text>
-    <text x="20" y="301" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>
+    <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6c4762" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c4762</text>
     <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.95</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#312232" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-DV</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#312232</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.99</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#81657f" rx="3"/>
+    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#81657f</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#be6b94" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#be6b94</text>
     <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#3d132d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-DV</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3d132d</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9b627a" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9b627a</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c47c7c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47c7c</text>
     <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#f1e2e0" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-LV</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f1e2e0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c29196" rx="3"/>
+    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29196</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
   </g>
 </svg>

--- a/debug/palettes/colorthief/starrail.svg
+++ b/debug/palettes/colorthief/starrail.svg
@@ -88,30 +88,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#696569" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#696569</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3135ac" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7d79bb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3135ac</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#585285" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#585285</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d82a38" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d82a38</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c9675a" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c9675a</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#402537" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#402537</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.03</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#696569" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#696569</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.55</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7d79bb</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a4a0d2" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a4a0d2</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.36</text>
+    <rect x="330" y="305" width="155" height="30" fill="#d82a38" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d82a38</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.44</text>
+    <rect x="485" y="305" width="155" height="30" fill="#cc7679" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc7679</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
   </g>
   <g transform="translate(0,372)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Aglaea</text>
@@ -205,23 +197,23 @@
     <rect x="20" y="305" width="124" height="30" fill="#a77d36" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#a77d36</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="144" y="305" width="124" height="30" fill="#8e785a" rx="3"/>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.58</text>
+    <rect x="144" y="305" width="124" height="30" fill="#938d6f" rx="3"/>
     <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#8e785a</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="268" y="305" width="124" height="30" fill="#3094b4" rx="3"/>
+    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#938d6f</text>
+    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.91</text>
+    <rect x="268" y="305" width="124" height="30" fill="#3dc9d2" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#3094b4</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="392" y="305" width="124" height="30" fill="#3dc9d2" rx="3"/>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#3dc9d2</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.04</text>
+    <rect x="392" y="305" width="124" height="30" fill="#3094b4" rx="3"/>
     <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#3dc9d2</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#3094b4</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
     <rect x="516" y="305" width="124" height="30" fill="#cf80f2" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#cf80f2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.20</text>
   </g>
   <g transform="translate(0,724)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Anaxa</text>
@@ -311,30 +303,26 @@
     <rect x="150" y="257" width="70" height="28" fill="#5ca46c" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#5ca46c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#1f476b" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#4b8eb1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1f476b</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#507993" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#507993</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b22835" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b22835</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b08956" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08956</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5ca46c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#5ca46c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.81</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cbdcd4" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cbdcd4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#4b8eb1</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.18</text>
+    <rect x="144" y="305" width="124" height="30" fill="#507993" rx="3"/>
+    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#507993</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.56</text>
+    <rect x="268" y="305" width="124" height="30" fill="#b22835" rx="3"/>
+    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b22835</text>
+    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.83</text>
+    <rect x="392" y="305" width="124" height="30" fill="#ae967d" rx="3"/>
+    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae967d</text>
+    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.79</text>
+    <rect x="516" y="305" width="124" height="30" fill="#5ca46c" rx="3"/>
+    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#5ca46c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
   </g>
   <g transform="translate(0,1076)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Archer</text>
@@ -425,30 +413,18 @@
     <rect x="220" y="257" width="70" height="28" fill="#3a2c34" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3a2c34</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b47c44" rx="3"/>
+    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#b47c44" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47c44</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ae7447" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ae7447</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8a0c1c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a0c1c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#69141e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#69141e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#584c54" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584c54</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.21</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8c848c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c848c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <text x="123.33333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47c44</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.41</text>
+    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#c7a890" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#c7a890</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.06</text>
+    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#8a0c1c" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="536.6666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8a0c1c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.16</text>
   </g>
   <g transform="translate(0,1428)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Argenti</text>
@@ -539,30 +515,14 @@
     <rect x="220" y="257" width="70" height="28" fill="#322932" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#322932</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c52a2f" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#dd6365" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c52a2f</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7d6c64" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d6c64</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d1b99c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d1b99c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.94</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a19990" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a19990</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#504955" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#504955</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.20</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8a8591" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a8591</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#dd6365</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.32</text>
+    <rect x="330" y="305" width="310" height="30" fill="#7d6c64" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7d6c64</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.69</text>
   </g>
   <g transform="translate(0,1780)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Aventurine</text>
@@ -652,30 +612,14 @@
     <rect x="150" y="257" width="70" height="28" fill="#5c6c6c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#5c6c6c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ac8250" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#b4646c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac8250</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b4646c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b4646c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#1d405b" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1d405b</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4d6b7c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4d6b7c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#304446" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#304446</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.11</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5c6c6c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6c6c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.23</text>
+    <rect x="330" y="305" width="310" height="30" fill="#867e7f" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#867e7f</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.25</text>
   </g>
   <g transform="translate(0,2132)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">BlackSwan</text>
@@ -767,26 +711,26 @@
     <rect x="80" y="257" width="70" height="28" fill="#bf935d" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#bf935d</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#2e4ad7" rx="3"/>
+    <rect x="20" y="305" width="124" height="30" fill="#7f6ed6" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2e4ad7</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="144" y="305" width="124" height="30" fill="#5143a3" rx="3"/>
+    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f6ed6</text>
+    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.79</text>
+    <rect x="144" y="305" width="124" height="30" fill="#686e8f" rx="3"/>
     <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5143a3</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#686e8f</text>
+    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
     <rect x="268" y="305" width="124" height="30" fill="#bc648f" rx="3"/>
     <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc648f</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
+    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.66</text>
     <rect x="392" y="305" width="124" height="30" fill="#826890" rx="3"/>
     <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826890</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
     <rect x="516" y="305" width="124" height="30" fill="#bf935d" rx="3"/>
     <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf935d</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.07</text>
   </g>
   <g transform="translate(0,2484)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Blade</text>
@@ -877,26 +821,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#78b6a9" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#78b6a9</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#b4371b" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#b4371b" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b4371b</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="144" y="305" width="124" height="30" fill="#b29178" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#b29178</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="268" y="305" width="124" height="30" fill="#314657" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#314657</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
-    <rect x="392" y="305" width="124" height="30" fill="#5a6973" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5a6973</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="516" y="305" width="124" height="30" fill="#78b6a9" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#78b6a9</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b4371b</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.87</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b29178" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b29178</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.84</text>
   </g>
   <g transform="translate(0,2836)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Boothill</text>
@@ -987,30 +919,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#666f70" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#666f70</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c23035" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#c23035" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23035</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.25</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#815b54" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#815b54</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8786a4" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8786a4</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.09</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#615c6e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#615c6e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#86b47a" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b47a</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.87</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#666f70" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666f70</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c23035</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.15</text>
+    <rect x="175" y="305" width="155" height="30" fill="#bd7786" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bd7786</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.25</text>
+    <rect x="330" y="305" width="155" height="30" fill="#86b47a" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#86b47a</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.53</text>
+    <rect x="485" y="305" width="155" height="30" fill="#666f70" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666f70</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.87</text>
   </g>
   <g transform="translate(0,3188)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Bronya</text>
@@ -1105,27 +1029,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#406fc5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#406fc5</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#2f3c8c" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.91</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#cdccce" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2f3c8c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#cdccce</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.91</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b0272f" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b0272f</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#a7815c" rx="3"/>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.71</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#765850" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#a7815c</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.03</text>
+    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#765850</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#71bfe6" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#71bfe6</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.57</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.71</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5c6565" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5c6565</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
   </g>
   <g transform="translate(0,3540)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Castorice</text>
@@ -1217,30 +1141,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#8cbcfc" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#8cbcfc</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f256d" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9a6db4" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f256d</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#6a5491" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#9a6db4</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.76</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9c91af" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a5491</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9c91af</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.93</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bcbc6c" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bcbc6c</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.72</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.78</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#584739" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#584739</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.58</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3193d3" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3193d3</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.88</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#2d56ac" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d56ac</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.35</text>
   </g>
   <g transform="translate(0,3892)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Cipher</text>
@@ -1332,30 +1256,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#c45c59" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c45c59</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#286ac8" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7988c1" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#286ac8</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#414b8d" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#7988c1</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.24</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a0b3cd" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#414b8d</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a0b3cd</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cd8b40" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cd8b40</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.58</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9f816f" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9f816f</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.50</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c45c59" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c45c59</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.53</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.72</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#cc8781" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc8781</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
   </g>
   <g transform="translate(0,4244)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Cyrene</text>
@@ -1445,26 +1369,22 @@
     <rect x="80" y="257" width="70" height="28" fill="#5cecfc" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#5cecfc</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#9d3fe5" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#9d3fe5" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d3fe5</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
-    <rect x="144" y="305" width="124" height="30" fill="#7e70b4" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#7e70b4</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="268" y="305" width="124" height="30" fill="#d4549c" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4549c</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="392" y="305" width="124" height="30" fill="#966384" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#966384</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="516" y="305" width="124" height="30" fill="#5cecfc" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#5cecfc</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.68</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d3fe5</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a791c8" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a791c8</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.90</text>
+    <rect x="330" y="305" width="155" height="30" fill="#c16ab8" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c16ab8</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
+    <rect x="485" y="305" width="155" height="30" fill="#b3869f" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b3869f</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
   </g>
   <g transform="translate(0,4596)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">DrRatio</text>
@@ -1555,30 +1475,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#d42f1c" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#d42f1c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5773d2" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#5773d2" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5773d2</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#44479d" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#44479d</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#8c8183" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c8183</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.21</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#261c1e" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#261c1e</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.98</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d42f1c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d42f1c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b37f6e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b37f6e</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5773d2</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.87</text>
+    <rect x="175" y="305" width="155" height="30" fill="#707792" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#707792</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.60</text>
+    <rect x="330" y="305" width="155" height="30" fill="#d42f1c" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d42f1c</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="485" y="305" width="155" height="30" fill="#d9c8c1" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d9c8c1</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.55</text>
   </g>
   <g transform="translate(0,4948)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Feixiao</text>
@@ -1668,30 +1580,14 @@
     <rect x="360" y="257" width="70" height="28" fill="#213040" rx="2"/>
     <text x="395" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#213040</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#c01a18" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#c01a18" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01a18</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ac875c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac875c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.07</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7fbec7" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7fbec7</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#4c7d84" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c7d84</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#34627c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#34627c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5287ab" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#5287ab</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c01a18</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.21</text>
+    <rect x="330" y="305" width="310" height="30" fill="#7e7068" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e7068</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.80</text>
   </g>
   <g transform="translate(0,5300)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Firefly</text>
@@ -1782,30 +1678,14 @@
     <rect x="290" y="257" width="70" height="28" fill="#d1ab78" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#d1ab78</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f7287" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f7287</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#87afb8" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#87afb8</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7c7cac" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7c7cac</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.96</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#857c82" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#857c82</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.45</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d4954f" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4954f</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b99486" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b99486</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
+    <rect x="20" y="305" width="310" height="30" fill="#d4954f" rx="3"/>
+    <text x="24" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#d4954f</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.37</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b99486" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b99486</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.58</text>
   </g>
   <g transform="translate(0,5652)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">FuXuan</text>
@@ -1897,26 +1777,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#f0d094" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#f0d094</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#4c1d84" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#8f5897" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c1d84</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="144" y="305" width="124" height="30" fill="#8f5897" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f5897</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="268" y="305" width="124" height="30" fill="#885963" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#885963</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
-    <rect x="392" y="305" width="124" height="30" fill="#603941" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#603941</text>
-    <text x="512" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
-    <rect x="516" y="305" width="124" height="30" fill="#f0d094" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#f0d094</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8f5897</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="330" y="305" width="310" height="30" fill="#9e83a8" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e83a8</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.87</text>
   </g>
   <g transform="translate(0,6004)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gallagher</text>
@@ -2007,30 +1875,14 @@
     <rect x="220" y="257" width="70" height="28" fill="#9e7e5c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#9e7e5c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#b6136d" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#b6136d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6136d</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b5658c" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5658c</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#474c69" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#474c69</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.99</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7f7c95" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f7c95</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#9e7e5c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e7e5c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.84</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a68c70" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a68c70</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b6136d</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b5658c" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5658c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.67</text>
   </g>
   <g transform="translate(0,6356)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Gepard</text>
@@ -2122,30 +1974,14 @@
     <rect x="220" y="257" width="70" height="28" fill="#3e3b4b" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3e3b4b</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#1834a1" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#3285ef" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1834a1</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#424c5f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#424c5f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#a37753" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a37753</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#945c4c" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#945c4c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3e3b4b" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3e3b4b</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.18</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bebac2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bebac2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.76</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#3285ef</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
+    <rect x="330" y="305" width="310" height="30" fill="#424c5f" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#424c5f</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.55</text>
   </g>
   <g transform="translate(0,6708)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Guinaifen</text>
@@ -2237,30 +2073,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#68b4c2" rx="2"/>
     <text x="185" y="277" fill="#000000" font-size="7" text-anchor="middle">#68b4c2</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#88373a" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#aa4f4e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#88373a</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.59</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#aa4f4e" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#aa4f4e</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d46b5f" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d46b5f</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7e6255" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7e6255</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#387c8e" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#387c8e</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#68b4c2" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#68b4c2</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#aa4f4e</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.54</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a494a9" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a494a9</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.83</text>
+    <rect x="330" y="305" width="155" height="30" fill="#d46b5f" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#d46b5f</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.01</text>
+    <rect x="485" y="305" width="155" height="30" fill="#a08780" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a08780</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.26</text>
   </g>
   <g transform="translate(0,7060)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Hanya</text>
@@ -2350,30 +2178,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#534c45" rx="2"/>
     <text x="325" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#534c45</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#395a7f" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#395a7f</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#758fac" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#758fac</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#c52a34" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c52a34</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#926d67" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#926d67</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c29461" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29461</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#ccae8c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ccae8c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
+    <rect x="20" y="305" width="155" height="30" fill="#c52a34" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c52a34</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.19</text>
+    <rect x="175" y="305" width="155" height="30" fill="#926d67" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#926d67</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.09</text>
+    <rect x="330" y="305" width="155" height="30" fill="#c29461" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29461</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.02</text>
+    <rect x="485" y="305" width="155" height="30" fill="#ccae8c" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#ccae8c</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.06</text>
   </g>
   <g transform="translate(0,7412)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Himekc</text>
@@ -2465,30 +2285,14 @@
     <rect x="220" y="257" width="70" height="28" fill="#445464" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#445464</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#9f171e" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#e27167" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9f171e</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#914e41" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#914e41</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#583e43" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#583e43</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.07</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#826f7b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#826f7b</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8cb8cc" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#8cb8cc</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#446474" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#446474</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e27167</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.31</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b39189" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b39189</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.99</text>
   </g>
   <g transform="translate(0,7764)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Huohuo</text>
@@ -2580,30 +2384,14 @@
     <rect x="220" y="257" width="70" height="28" fill="#37666a" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#37666a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#981d1c" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#c73d34" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#981d1c</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#98828b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#98828b</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#354d6a" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#354d6a</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#636e8f" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#636e8f</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.22</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#37666a" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#37666a</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.80</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#5b8f8c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#5b8f8c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c73d34</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.12</text>
+    <rect x="330" y="305" width="310" height="30" fill="#98828b" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#98828b</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.72</text>
   </g>
   <g transform="translate(0,8116)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Hyacine</text>
@@ -2697,27 +2485,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#bf2e53" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bf2e53</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.23</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#926478" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b48a77" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#926478</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48a77</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.76</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b427d5" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b427d5</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9b93ac" rx="3"/>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.76</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#c3afc1" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b93ac</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#c3afc1</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.15</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#48a4c1" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#48a4c1</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.34</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7193ae" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7193ae</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.75</text>
   </g>
   <g transform="translate(0,8468)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jade</text>
@@ -2811,27 +2599,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#665dcf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#665dcf</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.50</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.11</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#745f93" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#745f93</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.13</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b572b0" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b572b0</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#875f6c" rx="3"/>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.79</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#d7bfc6" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#875f6c</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#d7bfc6</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.77</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c44242" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#c44242</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.23</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#ba8e80" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#ba8e80</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.31</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.53</text>
   </g>
   <g transform="translate(0,8820)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jiaoqiu</text>
@@ -2921,26 +2709,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#686560" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#686560</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#b1363a" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#b1363a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b1363a</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="144" y="305" width="124" height="30" fill="#ae565c" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae565c</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="268" y="305" width="124" height="30" fill="#45647c" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#45647c</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
-    <rect x="392" y="305" width="124" height="30" fill="#688da7" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#688da7</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.10</text>
-    <rect x="516" y="305" width="124" height="30" fill="#686560" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#686560</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.22</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b1363a</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.63</text>
+    <rect x="330" y="305" width="310" height="30" fill="#b18b7f" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#b18b7f</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.82</text>
   </g>
   <g transform="translate(0,9172)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">JingYuan</text>
@@ -3031,30 +2807,18 @@
     <rect x="220" y="257" width="70" height="28" fill="#6ca0cc" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#6ca0cc</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ddba98" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#ddba98</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.83</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b2967f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b2967f</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#7c3c54" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7c3c54</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.71</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#562a2b" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#562a2b</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6ca0cc" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca0cc</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#386c7e" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#386c7e</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.38</text>
+    <rect x="20" y="305" width="206.66666666666666" height="30" fill="#7c3c54" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="123.33333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7c3c54</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.17</text>
+    <rect x="226.66666666666666" y="305" width="206.66666666666666" height="30" fill="#6ca0cc" rx="3"/>
+    <text x="230.66666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#6ca0cc</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.47</text>
+    <rect x="433.3333333333333" y="305" width="206.66666666666666" height="30" fill="#376074" rx="3"/>
+    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="536.6666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#376074</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.66</text>
   </g>
   <g transform="translate(0,9524)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Jingliu</text>
@@ -3145,30 +2909,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#b08265" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#b08265</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#5f7ec0" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#5f7ec0" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#5f7ec0</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#60729a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#60729a</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#857387" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#857387</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.15</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#5e505d" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5e505d</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b11012" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b11012</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b08265" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b08265</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#5f7ec0</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
+    <rect x="175" y="305" width="155" height="30" fill="#8dadd1" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#8dadd1</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b11012" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b11012</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <rect x="485" y="305" width="155" height="30" fill="#b49b97" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b49b97</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.49</text>
   </g>
   <g transform="translate(0,9876)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Lingsha</text>
@@ -3260,30 +3016,30 @@
     <rect x="220" y="257" width="70" height="28" fill="#3c846c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#3c846c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ae3724" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cb4f3a" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ae3724</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#cb4f3a</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#ac82b2" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ac82b2</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.29</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#d8c155" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8c155</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.00</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#84826f" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#84826f</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.54</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3c8c6c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#3c8c6c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.61</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.99</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#7eb3a0" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#7eb3a0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.26</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.22</text>
   </g>
   <g transform="translate(0,10228)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Luocha</text>
@@ -3373,26 +3129,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#0b090c" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#0b090c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#42676f" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#42676f</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.89</text>
-    <rect x="144" y="305" width="124" height="30" fill="#667d74" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#667d74</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.37</text>
-    <rect x="268" y="305" width="124" height="30" fill="#c48c4c" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48c4c</text>
-    <text x="388" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="392" y="305" width="124" height="30" fill="#b47c64" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#b47c64</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
-    <rect x="516" y="305" width="124" height="30" fill="#0b090c" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#0b090c</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.47</text>
+    <rect x="20" y="305" width="310" height="30" fill="#c48c4c" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#c48c4c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.39</text>
+    <rect x="330" y="305" width="310" height="30" fill="#90846e" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#90846e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.73</text>
   </g>
   <g transform="translate(0,10580)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">March7th</text>
@@ -3484,30 +3228,22 @@
     <rect x="360" y="257" width="70" height="28" fill="#f7e3c9" rx="2"/>
     <text x="395" y="277" fill="#000000" font-size="7" text-anchor="middle">#f7e3c9</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#45bdd3" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7590c8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#45bdd3</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7754af" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7754af</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#6d414c" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d414c</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.89</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b788a1" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b788a1</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c67154" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67154</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.49</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#e1b191" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1b191</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.75</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7590c8</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="175" y="305" width="155" height="30" fill="#b5b6d2" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#b5b6d2</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.45</text>
+    <rect x="330" y="305" width="155" height="30" fill="#c67154" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c67154</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.69</text>
+    <rect x="485" y="305" width="155" height="30" fill="#e1b191" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1b191</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.68</text>
   </g>
   <g transform="translate(0,10932)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Moze</text>
@@ -3598,30 +3334,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#a47664" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#a47664</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4f5199" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7577bf" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4f5199</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#676e95" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#676e95</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#320b2e" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#320b2e</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.86</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#845776" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#845776</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#b52d4f" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52d4f</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#a47664" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#a47664</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7577bf</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.44</text>
+    <rect x="175" y="305" width="155" height="30" fill="#979fc6" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#979fc6</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.39</text>
+    <rect x="330" y="305" width="155" height="30" fill="#b52d4f" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b52d4f</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.63</text>
+    <rect x="485" y="305" width="155" height="30" fill="#bb6990" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bb6990</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
   </g>
   <g transform="translate(0,11284)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Mydei</text>
@@ -3713,30 +3441,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#3154b6" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#3154b6</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#ca2b26" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#dd7566" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#ca2b26</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a17d6a" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a17d6a</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#621f25" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#621f25</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.64</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#7b5d70" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7b5d70</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#3154b6" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3154b6</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9d8fb0" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8fb0</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#dd7566</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.62</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a17d6a" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a17d6a</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.24</text>
+    <rect x="330" y="305" width="155" height="30" fill="#3154b6" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3154b6</text>
+    <text x="481" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.45</text>
+    <rect x="485" y="305" width="155" height="30" fill="#9d8fb0" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9d8fb0</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.70</text>
   </g>
   <g transform="translate(0,11636)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Phainon</text>
@@ -3826,30 +3546,22 @@
     <rect x="220" y="257" width="70" height="28" fill="#8c441c" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#8c441c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#506392" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#506392</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.78</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#7f86a0" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#7f86a0</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.30</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bf8a4a" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf8a4a</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.48</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9b8069" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8069</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.18</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#8c441c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c441c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.33</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bc7c6c" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc7c6c</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <rect x="20" y="305" width="155" height="30" fill="#bf8a4a" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bf8a4a</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.43</text>
+    <rect x="175" y="305" width="155" height="30" fill="#9b8069" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9b8069</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.71</text>
+    <rect x="330" y="305" width="155" height="30" fill="#bc7c6c" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bc7c6c</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.25</text>
+    <rect x="485" y="305" width="155" height="30" fill="#8c441c" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8c441c</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=6.87</text>
   </g>
   <g transform="translate(0,11988)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Rappa</text>
@@ -3944,27 +3656,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d7303d" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d7303d</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.49</text>
     <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#b87376" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
     <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#b87376</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.73</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#cc8233" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#cc8233</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#dada80" rx="3"/>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.86</text>
+    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#72df81" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#dada80</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.63</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4edbd3" rx="3"/>
+    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#72df81</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=6.32</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#7e88de" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#4edbd3</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.36</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#487bbc" rx="3"/>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#7e88de</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4edbd3" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#487bbc</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#4edbd3</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.81</text>
   </g>
   <g transform="translate(0,12340)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Robin</text>
@@ -4055,30 +3767,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#e5ccb3" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#e5ccb3</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#4540c2" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#7372bb" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4540c2</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#644c9f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#644c9f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9e88bd" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e88bd</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.92</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#bdadd5" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#bdadd5</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.66</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#6a4836" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6a4836</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.79</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#8b6f59" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#8b6f59</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.19</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#7372bb</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.86</text>
+    <rect x="175" y="305" width="155" height="30" fill="#a2a6d2" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#a2a6d2</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.37</text>
+    <rect x="330" y="305" width="155" height="30" fill="#9e88bd" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#9e88bd</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.33</text>
+    <rect x="485" y="305" width="155" height="30" fill="#bdadd5" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#bdadd5</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.08</text>
   </g>
   <g transform="translate(0,12692)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">RuanMei</text>
@@ -4170,26 +3874,14 @@
     <rect x="80" y="257" width="70" height="28" fill="#2d2e3a" rx="2"/>
     <text x="115" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#2d2e3a</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#d5993c" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#ca5262" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#000000" font-size="8" text-anchor="middle">#d5993c</text>
-    <text x="140" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.28</text>
-    <rect x="144" y="305" width="124" height="30" fill="#99857e" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#000000" font-size="8" text-anchor="middle">#99857e</text>
-    <text x="264" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="268" y="305" width="124" height="30" fill="#2c4e6c" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2c4e6c</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.67</text>
-    <rect x="392" y="305" width="124" height="30" fill="#538ea0" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#538ea0</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.06</text>
-    <rect x="516" y="305" width="124" height="30" fill="#2d2e3a" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2d2e3a</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.23</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#ca5262</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.99</text>
+    <rect x="330" y="305" width="310" height="30" fill="#99857e" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#99857e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.12</text>
   </g>
   <g transform="translate(0,13044)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Saber</text>
@@ -4281,30 +3973,22 @@
     <rect x="150" y="257" width="70" height="28" fill="#4b4c46" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#4b4c46</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3962cd" rx="3"/>
+    <rect x="20" y="305" width="155" height="30" fill="#3962cd" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3962cd</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#958fba" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#958fba</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.40</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#b5592b" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#b5592b</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#897067" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#897067</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#686c6a" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#686c6a</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.25</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4b4c46" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4b4c46</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.70</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3962cd</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.30</text>
+    <rect x="175" y="305" width="155" height="30" fill="#958fba" rx="3"/>
+    <text x="179" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="252.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#958fba</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
+    <rect x="330" y="305" width="155" height="30" fill="#c18247" rx="3"/>
+    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c18247</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
+    <rect x="485" y="305" width="155" height="30" fill="#897067" rx="3"/>
+    <text x="489" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#897067</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=9.02</text>
   </g>
   <g transform="translate(0,13396)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sparkle</text>
@@ -4399,27 +4083,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#cf263e" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#cf263e</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a64e5c" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.49</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#80726e" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#a64e5c</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
+    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#80726e</text>
+    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.20</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#2972cf" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2972cf</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.86</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#6d6499" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d6499</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
+    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.67</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#d8a146" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#d8a146</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.32</text>
+    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.63</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#dbb48a" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#dbb48a</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.65</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.65</text>
   </g>
   <g transform="translate(0,13748)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Sunday</text>
@@ -4509,26 +4193,6 @@
     <rect x="80" y="257" width="70" height="28" fill="#bcbca4" rx="2"/>
     <text x="115" y="277" fill="#000000" font-size="7" text-anchor="middle">#bcbca4</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="124" height="30" fill="#1e2765" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="82" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#1e2765</text>
-    <text x="140" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.60</text>
-    <rect x="144" y="305" width="124" height="30" fill="#626691" rx="3"/>
-    <text x="148" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="206" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#626691</text>
-    <text x="264" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.20</text>
-    <rect x="268" y="305" width="124" height="30" fill="#6d4c32" rx="3"/>
-    <text x="272" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="330" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6d4c32</text>
-    <text x="388" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.73</text>
-    <rect x="392" y="305" width="124" height="30" fill="#918483" rx="3"/>
-    <text x="396" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="454" y="331" fill="#000000" font-size="8" text-anchor="middle">#918483</text>
-    <text x="512" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="516" y="305" width="124" height="30" fill="#bcbca4" rx="3"/>
-    <text x="520" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="578" y="331" fill="#000000" font-size="8" text-anchor="middle">#bcbca4</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=1.19</text>
   </g>
   <g transform="translate(0,14100)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">TheHerta</text>
@@ -4619,30 +4283,30 @@
     <rect x="150" y="257" width="70" height="28" fill="#bc4c5c" rx="2"/>
     <text x="185" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#bc4c5c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#3418b8" rx="3"/>
+    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#8a7cc8" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#3418b8</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.11</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#605395" rx="3"/>
+    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#8a7cc8</text>
+    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.93</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#a7a7d3" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#605395</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.13</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#a7a7d3</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.14</text>
     <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#bd7dbf" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
     <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bd7dbf</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.82</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.62</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#8c7790" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#8c7790</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.35</text>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.34</text>
     <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#bc4c5c" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
     <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#bc4c5c</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.52</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.18</text>
     <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#b48864" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
     <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#b48864</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.15</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.43</text>
   </g>
   <g transform="translate(0,14452)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">TopazandNumby</text>
@@ -4734,30 +4398,22 @@
     <rect x="290" y="257" width="70" height="28" fill="#bba553" rx="2"/>
     <text x="325" y="277" fill="#000000" font-size="7" text-anchor="middle">#bba553</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#7a6788" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a6788</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=1.04</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#9795b6" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#9795b6</text>
-    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.44</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#de4152" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#de4152</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.29</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9d6578" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d6578</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.14</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#edca48" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#edca48</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.43</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#bba553" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#bba553</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.24</text>
+    <rect x="20" y="305" width="155" height="30" fill="#de4152" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#de4152</text>
+    <text x="171" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.72</text>
+    <rect x="175" y="305" width="155" height="30" fill="#9d6578" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9d6578</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.52</text>
+    <rect x="330" y="305" width="155" height="30" fill="#edca48" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#edca48</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.30</text>
+    <rect x="485" y="305" width="155" height="30" fill="#807165" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#807165</text>
+    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.74</text>
   </g>
   <g transform="translate(0,14804)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Tribbie</text>
@@ -4852,27 +4508,27 @@
     <rect x="20" y="305" width="103.33333333333333" height="30" fill="#d32e24" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
     <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#d32e24</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.09</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#986866" rx="3"/>
+    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.68</text>
+    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#e1bab7" rx="3"/>
     <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#986866</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.17</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#f49c49" rx="3"/>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#e1bab7</text>
+    <text x="222.66666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.89</text>
+    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#9a5b41" rx="3"/>
     <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#f49c49</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.51</text>
+    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9a5b41</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.52</text>
     <rect x="330" y="305" width="103.33333333333333" height="30" fill="#b58a6b" rx="3"/>
     <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
     <text x="381.6666666666667" y="331" fill="#000000" font-size="8" text-anchor="middle">#b58a6b</text>
-    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#5d389d" rx="3"/>
+    <text x="429.3333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.17</text>
+    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#4c6cb6" rx="3"/>
     <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#5d389d</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.47</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#4c6cb6" rx="3"/>
+    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c6cb6</text>
+    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.19</text>
+    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#9089a4" rx="3"/>
     <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#4c6cb6</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.21</text>
+    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#9089a4</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.90</text>
   </g>
   <g transform="translate(0,15156)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">Yunli</text>
@@ -4964,30 +4620,14 @@
     <rect x="220" y="257" width="70" height="28" fill="#342c54" rx="2"/>
     <text x="255" y="277" fill="#ffffff" font-size="7" text-anchor="middle">#342c54</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#db573c" rx="3"/>
+    <rect x="20" y="305" width="310" height="30" fill="#db573c" rx="3"/>
     <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#000000" font-size="8" text-anchor="middle">#db573c</text>
-    <text x="119.33333333333333" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.27</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#90605b" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#90605b</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.16</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#2b757a" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#2b757a</text>
-    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.56</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#425e68" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#425e68</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.46</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#342c54" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#342c54</text>
-    <text x="532.6666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.90</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#666c7b" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#666c7b</text>
-    <text x="636" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.39</text>
+    <text x="175" y="331" fill="#000000" font-size="8" text-anchor="middle">#db573c</text>
+    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.47</text>
+    <rect x="330" y="305" width="310" height="30" fill="#a5837e" rx="3"/>
+    <text x="334" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
+    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#a5837e</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=9.90</text>
   </g>
   <g transform="translate(0,15508)">
     <text x="20" y="18" fill="#aaaaaa" font-size="13" font-weight="bold">kafka</text>
@@ -5077,29 +4717,21 @@
     <rect x="220" y="257" width="70" height="28" fill="#c47c7c" rx="2"/>
     <text x="255" y="277" fill="#000000" font-size="7" text-anchor="middle">#c47c7c</text>
     <text x="20" y="301" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>
-    <rect x="20" y="305" width="103.33333333333333" height="30" fill="#6c4762" rx="3"/>
-    <text x="24" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-V</text>
-    <text x="71.66666666666666" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#6c4762</text>
-    <text x="119.33333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.95</text>
-    <rect x="123.33333333333333" y="305" width="103.33333333333333" height="30" fill="#81657f" rx="3"/>
-    <text x="127.33333333333333" y="317" fill="#ff9966" font-size="8" font-weight="bold" opacity="0.9">main-M</text>
-    <text x="175" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#81657f</text>
-    <text x="222.66666666666666" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.34</text>
-    <rect x="226.66666666666666" y="305" width="103.33333333333333" height="30" fill="#be6b94" rx="3"/>
-    <text x="230.66666666666666" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
-    <text x="278.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#be6b94</text>
-    <text x="326" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.69</text>
-    <rect x="330" y="305" width="103.33333333333333" height="30" fill="#9b627a" rx="3"/>
-    <text x="334" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
-    <text x="381.6666666666667" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9b627a</text>
-    <text x="429.3333333333333" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">d=0.12</text>
-    <rect x="433.3333333333333" y="305" width="103.33333333333333" height="30" fill="#c47c7c" rx="3"/>
-    <text x="437.3333333333333" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
-    <text x="485" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47c7c</text>
-    <text x="532.6666666666666" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.77</text>
-    <rect x="536.6666666666666" y="305" width="103.33333333333333" height="30" fill="#c29196" rx="3"/>
-    <text x="540.6666666666666" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
-    <text x="588.3333333333333" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29196</text>
-    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">d=0.41</text>
+    <rect x="20" y="305" width="155" height="30" fill="#9b627a" rx="3"/>
+    <text x="24" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-V</text>
+    <text x="97.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#9b627a</text>
+    <text x="171" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=7.70</text>
+    <rect x="175" y="305" width="155" height="30" fill="#7a6d70" rx="3"/>
+    <text x="179" y="317" fill="#66ccff" font-size="8" font-weight="bold" opacity="0.9">sub-M</text>
+    <text x="252.5" y="331" fill="#ffffff" font-size="8" text-anchor="middle">#7a6d70</text>
+    <text x="326" y="317" fill="#ffffff" font-size="7" text-anchor="end" opacity="0.6">s=8.05</text>
+    <rect x="330" y="305" width="155" height="30" fill="#c47c7c" rx="3"/>
+    <text x="334" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-V</text>
+    <text x="407.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c47c7c</text>
+    <text x="481" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=7.28</text>
+    <rect x="485" y="305" width="155" height="30" fill="#c29196" rx="3"/>
+    <text x="489" y="317" fill="#cc66ff" font-size="8" font-weight="bold" opacity="0.9">accent-M</text>
+    <text x="562.5" y="331" fill="#000000" font-size="8" text-anchor="middle">#c29196</text>
+    <text x="636" y="317" fill="#000000" font-size="7" text-anchor="end" opacity="0.6">s=8.50</text>
   </g>
 </svg>

--- a/docs/projects/features/R2/README.md
+++ b/docs/projects/features/R2/README.md
@@ -12,7 +12,8 @@
 | V4  | node-vibrant MMCQ 64色 + mini.hues     | 生成色が浮く / HSL-OkLch 混在の複雑さ / R1 の3軸を活かせていない |
 | V5  | 3 seed × tonal palette (HCT) + neutral | 各軸1色では特徴色を逃す / seed スコアリングが OkLch 依存 |
 | V6  | 3 target seed (V/DV/LV) × 閾値段階緩和 | seed 数が軸・キャラで 1〜3 にばらつく / tonal palette 以降は未実装 |
-| V7  | V + DV/LV 競合選定で seed 数固定化 | 開発中 |
+| V7  | V + DV/LV 競合選定で seed 数固定化 | node-vibrant HSL ベースで colorthief の Vibrant と不一致 |
+| V8  | colorthief 準拠 OkLch Vibrant + Muted | — |
 
 ## 設計変遷
 
@@ -45,12 +46,17 @@ V6: "3 target seed（V/DV/LV）× 閾値段階緩和で軸あたり最大3色"
 V7: "V + DV/LV 競合選定で seed 数を固定 6"
      + 2色目は DV/LV の距離比較で近い方を採用
      + キャラによって DV/LV が自動選択される
-     → 開発中
+     → node-vibrant HSL ベースで colorthief の Vibrant と不一致
+
+V8: "colorthief 準拠 OkLch Vibrant + Muted"
+     + colorthief の swatches.ts と同じスコアリング
+     + population を正規化加算
+     + 範囲フィルタ廃止（軸内少数色に対応）
 ```
 
-## 現行: V7
+## 現行: V8
 
-[`V7/plan.md`](V7/plan.md)
+[`V8/spec.md`](V8/spec.md)
 
 ## VX/ 配下のファイル命名規則
 

--- a/docs/projects/features/R2/V8/plan.md
+++ b/docs/projects/features/R2/V8/plan.md
@@ -1,0 +1,21 @@
+# R2/V8 colorthief 準拠 Vibrant + Muted スコアリング
+
+## なぜ V8 が必要か
+
+V7（V + DV/LV 競合選定）は node-vibrant の HSL ベーススコアリングを使用していたが、colorthief の実際のソースコードを確認したところ、colorthief は OkLch ベースで Vibrant/Muted を選定していることが判明した。
+
+node-vibrant 方式では colorthief が画像全体で選ぶ Vibrant と、軸内で選ぶ Vibrant が一致しないケースがあった（例: Nilou の accent 軸で #c75f3f が Vibrant に選ばれない）。
+
+## 前版との変更対照表
+
+| 項目 | V7 | V8 |
+| ---- | ---- | ------ |
+| スコアリング色空間 | HSL (saturation/luma) | OkLch (L/C) |
+| target | node-vibrant 方式 (V/DV/LV) | colorthief 方式 (Vibrant/Muted) |
+| スコア方向 | 距離が小さいほど良い | スコアが高いほど良い |
+| population | 未使用 → 後付け減算 | colorthief 準拠で正規化加算 |
+| 範囲フィルタ | なし | 廃止（colorthief は持つが軸内少数色では厳しすぎる） |
+
+## 設計方針
+
+colorthief の `swatches.ts` のスコアリングロジックを軸内に適用する。2色目の選定を DV/LV 競合から Muted target に変更し、Vibrant（鮮やか）+ Muted（控えめ）の 2 seed 構成にする。

--- a/docs/projects/features/R2/V8/spec.md
+++ b/docs/projects/features/R2/V8/spec.md
@@ -1,0 +1,74 @@
+# R2/V8 仕様
+
+## 実装スコープ
+
+`scripts/gen-palette-svg-sharp.ts` の seed 選定を colorthief 準拠の OkLch Vibrant + Muted スコアリングに変更した。
+
+## 全体フロー
+
+```
+画像 → colorthief getPalette (16色)
+     → deriveColorAxes (R1: K=3 hue クラスタリング → main/sub/accent)
+     → selectSeeds (各軸から Vibrant + Muted の 2 seed を選定)
+     → SVG 描画 (最大6 seeds 表示)
+```
+
+## seed 選定（colorthief 準拠スコアリング）
+
+### target 定義
+
+colorthief の `swatches.ts` と同じ OkLch ベース:
+
+| target | targetL | targetC | 用途 |
+| --- | --- | --- | --- |
+| Vibrant (V) | 0.65 | 0.20 | 鮮やかな特徴色 → syntax fg |
+| Muted (M) | 0.65 | 0.04 | 控えめな色味 → UI |
+
+### スコアリング関数
+
+```
+score(color, target, maxPopulation) =
+  lDist * W_L + cDist * W_C + popNorm * W_POP
+
+lDist = 1 - |color.l - target.targetL|
+cDist = 1 - min(|color.c - target.targetC| / 0.2, 1)
+popNorm = color.population / maxPopulation
+```
+
+高いほど良い。範囲フィルタ（minL/maxL/minC）は廃止。colorthief は画像全体の 16色から選ぶため範囲フィルタが有効だが、軸内の少数色（3〜5色）では厳しすぎて seed が取れなくなるため。
+
+### 選定ロジック
+
+`selectSeeds(colors: Color[]): [SeedEntry, SeedEntry] | [SeedEntry]`
+
+1. 軸内の全色の population 最大値を取得（正規化用）
+2. Vibrant target で最高スコアの色を1色目に選定
+3. 1色目を除外し、Muted target で最高スコアの色を2色目に選定
+
+## 主要な定数
+
+| 定数 | 値 | 説明 |
+| --- | --- | --- |
+| `SWATCH_TARGETS.V.targetL` | 0.65 | Vibrant の OkLch lightness target |
+| `SWATCH_TARGETS.V.targetC` | 0.20 | Vibrant の OkLch chroma target |
+| `SWATCH_TARGETS.M.targetL` | 0.65 | Muted の OkLch lightness target |
+| `SWATCH_TARGETS.M.targetC` | 0.04 | Muted の OkLch chroma target |
+| `W_L` | 6 | lightness の重み |
+| `W_C` | 3 | chroma の重み |
+| `W_POP` | 1 | population の重み |
+
+## 主要な型定義
+
+```typescript
+type SwatchTarget = "V" | "M";
+type TargetDef = { targetL: number; targetC: number };
+type SeedEntry = { color: Color; score: number; swatchTarget: SwatchTarget };
+type SeedInfo = ColorInfo & { score: number; swatchTarget: SwatchTarget };
+```
+
+## 未実装
+
+- tonal palette 生成
+- ロール割り当て
+- ハイライトマッピング
+- 本番コード `src/features/` への移植

--- a/scripts/gen-palette-svg-sharp.ts
+++ b/scripts/gen-palette-svg-sharp.ts
@@ -19,80 +19,108 @@ const OPTIONS = { ...OPTIONS_BASE, colorCount: 16 };
 
 const DOMINANT_COUNT = 5;
 
-// --- seed スコアリング（Vibrant + Muted 選定） ---
+// --- seed スコアリング（colorthief 準拠 OkLch Vibrant + Muted） ---
 
 type SwatchTarget = "V" | "M";
 
-/** node-vibrant 準拠の target（saturation, luma は 0-1） */
-const SWATCH_TARGETS: Record<
-  SwatchTarget,
-  { saturation: number; luma: number }
-> = {
-  V: { saturation: 0.74, luma: 0.45 },
-  M: { saturation: 0.3, luma: 0.5 },
+/** colorthief の swatch target 定義（OkLch ベース） */
+type TargetDef = {
+  targetL: number;
+  minL: number;
+  maxL: number;
+  targetC: number;
+  minC: number;
 };
 
-/** node-vibrant 準拠の重み付き距離 */
-const W_SATURATION = 3;
-const W_LUMA = 6.5;
+const SWATCH_TARGETS: Record<SwatchTarget, TargetDef> = {
+  V: { targetL: 0.65, minL: 0.4, maxL: 0.85, targetC: 0.2, minC: 0.08 },
+  M: { targetL: 0.65, minL: 0.4, maxL: 0.85, targetC: 0.04, minC: 0.0 },
+};
 
-const targetDistance = (
-  saturation: number,
-  luma: number,
-  target: { saturation: number; luma: number },
+/** colorthief 準拠のスコアリング重み */
+const W_L = 6;
+const W_C = 3;
+const W_POP = 1;
+
+/**
+ * colorthief 準拠のスコアリング（高いほど良い）
+ *
+ * 範囲外は -Infinity で失格。
+ * スコア = lDist * W_L + cDist * W_C + popNorm * W_POP
+ */
+const swatchScore = (
+  color: Color,
+  target: TargetDef,
+  maxPopulation: number,
 ): number => {
-  const ds = saturation - target.saturation;
-  const dl = luma - target.luma;
-  return Math.sqrt(W_SATURATION * ds * ds + W_LUMA * dl * dl);
+  const { l, c } = color.oklch();
+
+  if (l < target.minL || l > target.maxL) return -Infinity;
+  if (c < target.minC) return -Infinity;
+
+  const lDist = 1 - Math.abs(l - target.targetL);
+  const cDist = 1 - Math.min(Math.abs(c - target.targetC) / 0.2, 1);
+  const pop = maxPopulation > 0 ? color.population / maxPopulation : 0;
+
+  return lDist * W_L + cDist * W_C + pop * W_POP;
 };
 
 type SeedEntry = {
   color: Color;
-  distance: number;
+  score: number;
   swatchTarget: SwatchTarget;
 };
 
-/** 色群から target に最も近い色を返す（除外 index 指定可） */
-const findClosest = (
+/** 色群から target に最もスコアが高い色を返す（除外 index 指定可） */
+const findBest = (
   colors: Color[],
-  target: { saturation: number; luma: number },
+  target: TargetDef,
   excludeIndices: Set<number>,
-): { idx: number; distance: number } | null => {
+  maxPopulation: number,
+): { idx: number; score: number } | null => {
   let bestIdx = -1;
-  let bestDist = Infinity;
+  let bestScore = -Infinity;
   for (let i = 0; i < colors.length; i++) {
     if (excludeIndices.has(i)) continue;
-    const hsl = colors[i].hsl();
-    const dist = targetDistance(hsl.s / 100, hsl.l / 100, target);
-    if (dist < bestDist) {
-      bestDist = dist;
+    const s = swatchScore(colors[i], target, maxPopulation);
+    if (s > bestScore) {
+      bestScore = s;
       bestIdx = i;
     }
   }
-  return bestIdx === -1 ? null : { idx: bestIdx, distance: bestDist };
+  return bestIdx === -1 || bestScore === -Infinity
+    ? null
+    : { idx: bestIdx, score: bestScore };
 };
 
 /**
- * 軸内から固定 2 seed を選定（Vibrant + Muted）
+ * 軸内から固定 2 seed を選定（colorthief 準拠 Vibrant + Muted）
  *
- * 1色目: Vibrant target で最も近い色（鮮やか → syntax fg 向き）
- * 2色目: Muted target で最も近い色（控えめ → UI 向き）
+ * 1色目: Vibrant target で最高スコアの色（鮮やか → syntax fg 向き）
+ * 2色目: Muted target で最高スコアの色（控えめ → UI 向き）
  */
 const selectSeeds = (colors: Color[]): [SeedEntry, SeedEntry] | [SeedEntry] => {
-  const vResult = findClosest(colors, SWATCH_TARGETS.V, new Set());
+  const maxPop = Math.max(...colors.map((c) => c.population), 1);
+
+  const vResult = findBest(colors, SWATCH_TARGETS.V, new Set(), maxPop);
   if (!vResult) return [] as unknown as [SeedEntry];
   const vSeed: SeedEntry = {
     color: colors[vResult.idx],
-    distance: vResult.distance,
+    score: vResult.score,
     swatchTarget: "V",
   };
 
-  const mResult = findClosest(colors, SWATCH_TARGETS.M, new Set([vResult.idx]));
+  const mResult = findBest(
+    colors,
+    SWATCH_TARGETS.M,
+    new Set([vResult.idx]),
+    maxPop,
+  );
   if (!mResult) return [vSeed];
 
   const mSeed: SeedEntry = {
     color: colors[mResult.idx],
-    distance: mResult.distance,
+    score: mResult.score,
     swatchTarget: "M",
   };
 
@@ -155,7 +183,7 @@ const AXIS_LABEL_COUNT_OFFSET_X = 38;
 
 type SwatchRole = (typeof SWATCH_ROLES)[number];
 type ColorInfo = { hex: string; isDark: boolean };
-type SeedInfo = ColorInfo & { distance: number; swatchTarget: SwatchTarget };
+type SeedInfo = ColorInfo & { score: number; swatchTarget: SwatchTarget };
 type AxisInfo = {
   role: string;
   colors: ColorInfo[];
@@ -306,7 +334,7 @@ const generateBlock = (
     const seedCellW = USABLE_W / Math.max(slots.length, 1);
     for (let si = 0; si < slots.length; si++) {
       const { label, axisRole, seed } = slots[si];
-      const { hex, isDark, distance } = seed;
+      const { hex, isDark, score } = seed;
       const textColor = isDark ? "#ffffff" : "#000000";
       const roleColor = ROLE_COLORS[axisRole] ?? FALLBACK_ROLE_COLOR;
       const x = PAD + si * seedCellW;
@@ -322,7 +350,7 @@ const generateBlock = (
         `    <text x="${cx}" y="${Y_SEED + H_SEED - 8}" fill="${textColor}" font-size="8" text-anchor="middle">${hex}</text>`,
       );
       lines.push(
-        `    <text x="${x + seedCellW - 4}" y="${Y_SEED + 20}" fill="${textColor}" font-size="7" text-anchor="end" opacity="0.6">d=${distance.toFixed(2)}</text>`,
+        `    <text x="${x + seedCellW - 4}" y="${Y_SEED + 20}" fill="${textColor}" font-size="7" text-anchor="end" opacity="0.6">s=${score.toFixed(2)}</text>`,
       );
     }
   }
@@ -391,7 +419,7 @@ for (const game of ["genshin", "starrail"] as const) {
         colors: axis.colors.map(toColorInfo),
         seeds: seeds.map((s) => ({
           ...toColorInfo(s.color),
-          distance: s.distance,
+          score: s.score,
           swatchTarget: s.swatchTarget,
         })),
       };

--- a/scripts/gen-palette-svg-sharp.ts
+++ b/scripts/gen-palette-svg-sharp.ts
@@ -19,18 +19,17 @@ const OPTIONS = { ...OPTIONS_BASE, colorCount: 16 };
 
 const DOMINANT_COUNT = 5;
 
-// --- seed スコアリング（V + DV/LV 競合選定） ---
+// --- seed スコアリング（Vibrant + Muted 選定） ---
 
-type VibrantRole = "V" | "DV" | "LV";
+type SwatchTarget = "V" | "M";
 
-/** node-vibrant の 3 target（saturation, luma は 0-1） */
-const VIBRANT_TARGETS: Record<
-  VibrantRole,
+/** node-vibrant 準拠の target（saturation, luma は 0-1） */
+const SWATCH_TARGETS: Record<
+  SwatchTarget,
   { saturation: number; luma: number }
 > = {
   V: { saturation: 0.74, luma: 0.45 },
-  DV: { saturation: 0.74, luma: 0.26 },
-  LV: { saturation: 0.74, luma: 0.74 },
+  M: { saturation: 0.3, luma: 0.5 },
 };
 
 /** node-vibrant 準拠の重み付き距離 */
@@ -50,10 +49,10 @@ const targetDistance = (
 type SeedEntry = {
   color: Color;
   distance: number;
-  vibrantRole: VibrantRole;
+  swatchTarget: SwatchTarget;
 };
 
-/** 色の index と target への距離 */
+/** 色群から target に最も近い色を返す（除外 index 指定可） */
 const findClosest = (
   colors: Color[],
   target: { saturation: number; luma: number },
@@ -74,57 +73,30 @@ const findClosest = (
 };
 
 /**
- * 軸内から固定 2 seed を選定（V + DV/LV 競合）
+ * 軸内から固定 2 seed を選定（Vibrant + Muted）
  *
- * 1色目: V target で最も近い色
- * 2色目: V を除外し、DV/LV の距離を比較 → 近い方を採用
+ * 1色目: Vibrant target で最も近い色（鮮やか → syntax fg 向き）
+ * 2色目: Muted target で最も近い色（控えめ → UI 向き）
  */
 const selectSeeds = (colors: Color[]): [SeedEntry, SeedEntry] | [SeedEntry] => {
-  // 1色目: Vibrant
-  const vResult = findClosest(colors, VIBRANT_TARGETS.V, new Set());
+  const vResult = findClosest(colors, SWATCH_TARGETS.V, new Set());
   if (!vResult) return [] as unknown as [SeedEntry];
   const vSeed: SeedEntry = {
     color: colors[vResult.idx],
     distance: vResult.distance,
-    vibrantRole: "V",
+    swatchTarget: "V",
   };
 
-  // 2色目: DV vs LV 競合
-  const excluded = new Set([vResult.idx]);
-  const dvResult = findClosest(colors, VIBRANT_TARGETS.DV, excluded);
-  const lvResult = findClosest(colors, VIBRANT_TARGETS.LV, excluded);
+  const mResult = findClosest(colors, SWATCH_TARGETS.M, new Set([vResult.idx]));
+  if (!mResult) return [vSeed];
 
-  // 未使用色がない（軸内に1色しかない）
-  if (!dvResult && !lvResult) return [vSeed];
+  const mSeed: SeedEntry = {
+    color: colors[mResult.idx],
+    distance: mResult.distance,
+    swatchTarget: "M",
+  };
 
-  let secondSeed: SeedEntry;
-  if (!dvResult) {
-    secondSeed = {
-      color: colors[lvResult!.idx],
-      distance: lvResult!.distance,
-      vibrantRole: "LV",
-    };
-  } else if (!lvResult) {
-    secondSeed = {
-      color: colors[dvResult.idx],
-      distance: dvResult.distance,
-      vibrantRole: "DV",
-    };
-  } else if (dvResult.distance <= lvResult.distance) {
-    secondSeed = {
-      color: colors[dvResult.idx],
-      distance: dvResult.distance,
-      vibrantRole: "DV",
-    };
-  } else {
-    secondSeed = {
-      color: colors[lvResult.idx],
-      distance: lvResult.distance,
-      vibrantRole: "LV",
-    };
-  }
-
-  return [vSeed, secondSeed];
+  return [vSeed, mSeed];
 };
 
 // --- SVG レイアウト定数 ---
@@ -183,7 +155,7 @@ const AXIS_LABEL_COUNT_OFFSET_X = 38;
 
 type SwatchRole = (typeof SWATCH_ROLES)[number];
 type ColorInfo = { hex: string; isDark: boolean };
-type SeedInfo = ColorInfo & { distance: number; vibrantRole: VibrantRole };
+type SeedInfo = ColorInfo & { distance: number; swatchTarget: SwatchTarget };
 type AxisInfo = {
   role: string;
   colors: ColorInfo[];
@@ -312,10 +284,10 @@ const generateBlock = (
     }
   }
 
-  // Seed Colors（各軸 V + DV/LV 競合 = 固定6 seeds）
+  // Seed Colors（各軸 Vibrant + Muted = 固定6 seeds）
   if (result.axes.length > 0) {
     lines.push(
-      `    <text x="${PAD}" y="${Y_SEED + 4}" fill="#888888" font-size="9">seed colors (V + DV/LV)</text>`,
+      `    <text x="${PAD}" y="${Y_SEED + 4}" fill="#888888" font-size="9">seed colors (Vibrant + Muted)</text>`,
     );
 
     // seed を flat なリストに展開
@@ -324,7 +296,7 @@ const generateBlock = (
     for (const axis of result.axes) {
       for (const seed of axis.seeds) {
         slots.push({
-          label: `${axis.role}-${seed.vibrantRole}`,
+          label: `${axis.role}-${seed.swatchTarget}`,
           axisRole: axis.role,
           seed,
         });
@@ -409,7 +381,7 @@ for (const game of ["genshin", "starrail"] as const) {
       }),
     ) as Record<SwatchRole, ColorInfo | null>;
 
-    // Color Axes + Seed 選定（V + DV/LV 競合）
+    // Color Axes + Seed 選定（Vibrant + Muted）
     const paletteColors = palette ?? [];
     const colorAxes = deriveColorAxes(paletteColors);
     const axes: AxisInfo[] = colorAxes.map((axis) => {
@@ -420,7 +392,7 @@ for (const game of ["genshin", "starrail"] as const) {
         seeds: seeds.map((s) => ({
           ...toColorInfo(s.color),
           distance: s.distance,
-          vibrantRole: s.vibrantRole,
+          swatchTarget: s.swatchTarget,
         })),
       };
     });

--- a/scripts/gen-palette-svg-sharp.ts
+++ b/scripts/gen-palette-svg-sharp.ts
@@ -26,15 +26,12 @@ type SwatchTarget = "V" | "M";
 /** colorthief の swatch target 定義（OkLch ベース） */
 type TargetDef = {
   targetL: number;
-  minL: number;
-  maxL: number;
   targetC: number;
-  minC: number;
 };
 
 const SWATCH_TARGETS: Record<SwatchTarget, TargetDef> = {
-  V: { targetL: 0.65, minL: 0.4, maxL: 0.85, targetC: 0.2, minC: 0.08 },
-  M: { targetL: 0.65, minL: 0.4, maxL: 0.85, targetC: 0.04, minC: 0.0 },
+  V: { targetL: 0.65, targetC: 0.2 },
+  M: { targetL: 0.65, targetC: 0.04 },
 };
 
 /** colorthief 準拠のスコアリング重み */
@@ -54,9 +51,6 @@ const swatchScore = (
   maxPopulation: number,
 ): number => {
   const { l, c } = color.oklch();
-
-  if (l < target.minL || l > target.maxL) return -Infinity;
-  if (c < target.minC) return -Infinity;
 
   const lDist = 1 - Math.abs(l - target.targetL);
   const cDist = 1 - Math.min(Math.abs(c - target.targetC) / 0.2, 1);


### PR DESCRIPTION
## Summary

- seed 選定を colorthief の `swatches.ts` と同じ OkLch ベーススコアリングに変更
- Vibrant + Muted の 2 target で各軸から 2 seed を選定
- population を正規化加算（colorthief 準拠）
- 範囲フィルタ（minL/maxL/minC）を廃止し、軸内少数色でも seed が取れるように

## Related

- docs: [R2/V8 spec.md](docs/projects/features/R2/V8/spec.md)

## Test plan

- [x] `vp build` 成功
- [x] `vp lint` 成功
- [x] `npx tsx scripts/gen-palette-svg-sharp.ts` で全キャラ正常生成
- [x] main/sub 100%、accent 94% で 2 seeds 取得を確認
- [x] Nilou の accent-V が colorthief の Vibrant (#c75f3f) と一致